### PR TITLE
Added WrappedComponent property to translate wrapper

### DIFF
--- a/src/translate.js
+++ b/src/translate.js
@@ -61,6 +61,8 @@ function translate(namespaces) {
         }
     }
 
+    Translate.WrappedComponent = WrappedComponent;
+
     Translate.contextTypes = {
       i18n: PropTypes.object.isRequired
     };


### PR DESCRIPTION
When you wrap component in translate, you loose any reference to it.
This is for example required when you're doing server-side rendering, and Component defines which actions to do to prefetch data.

Same approach is used in react-redux [connect wrapper](https://github.com/reactjs/react-redux/blob/v4.4.0/src/components/connect.js#L288)