### PR TITLE
Missing comma in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "test/",
     "dist/",
     "src/",
-    "bin/"
+    "bin/",
     "coverage/",
     "example/",
     ".babelrc",


### PR DESCRIPTION
Hello,

I found there was something missing in the bower.json, i.e. missing comma near the 'bin/', this is going to make bower installation be failed. Would you please fix it?? Thank you for this great works. :)