### PR TITLE
Fix i18n is not defined on component mount/unmount after hmr

### DIFF
--- a/src/translate.js
+++ b/src/translate.js
@@ -8,13 +8,12 @@ export default function translate(namespaces, options = {}) {
   const { withRef = false, wait = false } = options;
 
   return function Wrapper(WrappedComponent) {
-    let i18n;
 
     class Translate extends Component {
       constructor(props, context) {
         super(props, context);
-        i18n = context.i18n;
-        namespaces = namespaces || i18n.options.defaultNS;
+        this.i18n = context.i18n;
+        namespaces = namespaces || this.i18n.options.defaultNS;
 
         this.state = {
           i18nLoadedAt: null,
@@ -30,21 +29,21 @@ export default function translate(namespaces, options = {}) {
 
       componentWillMount() {
         this.mounted = true;
-        i18n.loadNamespaces(namespaces, () => {
+        this.i18n.loadNamespaces(namespaces, () => {
           this.setState({ ready: true });
         });
-        this.t = i18n.getFixedT(null, namespaces);
+        this.t = this.i18n.getFixedT(null, namespaces);
       }
 
       componentDidMount() {
-        i18n.on('languageChanged loaded', this.onI18nChanged);
+        this.i18n.on('languageChanged loaded', this.onI18nChanged);
       }
 
       componentWillUnmount() {
         this.mounted = false;
         if (this.onI18nChanged) {
-          i18n.off('languageChanged', this.onI18nChanged);
-          i18n.off('loaded', this.onI18nChanged);
+          this.i18n.off('languageChanged', this.onI18nChanged);
+          this.i18n.off('loaded', this.onI18nChanged);
         }
       }
 


### PR DESCRIPTION
I've been experiencing errors with hot module reloading with react-i18next. https://github.com/i18next/react-i18next/pull/112 helped; I don't get an error immediately on the hot module reload anymore.

However, I still do get an error when a hot module reload occurs, and I then do something which mounts or unmounts a translated component (route change, for instance).

Error is either
- Cannot read property 'loadNamespaces' of undefined (https://github.com/i18next/react-i18next/issues/62)
- Cannot read property 'off' of undefined

depending on whether componentWillMount or componentWillUnmount occurs first.

Cause and fix are the same as https://github.com/i18next/react-i18next/pull/112, just with the i18n local variable this time. 