### PR TITLE
Fix bug with undefined store in translate component

### DIFF
--- a/src/translate.js
+++ b/src/translate.js
@@ -38,7 +38,7 @@ export default function translate(namespaces, options = {}) {
           if (this.mounted) this.setState({ ready: true });
         });
         this.i18n.on('languageChanged loaded', this.onI18nChanged);
-        this.i18n.store.on('added removed', this.onI18nChanged);
+        this.i18n.store && this.i18n.store.on('added removed', this.onI18nChanged);
       }
 
       componentWillUnmount() {


### PR DESCRIPTION
Hello, `this.i18n.store` prop is not always ready/defined to the time when component is loaded. I'm using redux and it occurs with me after React 15.2.1