### PR TITLE
Support classnames on parents of interpolated components

### DIFF
--- a/src/interpolate.js
+++ b/src/interpolate.js
@@ -19,6 +19,7 @@ class Interpolate extends Component {
 
     let tOpts = {...{}, ...this.props.options, ...{interpolation: { prefix: '#$?', suffix: '?$#'}}}
     let format = this.t(this.props.i18nKey, tOpts);
+    let className = this.props.className;
 
     if (!format || typeof format !== 'string') return React.createElement('noscript', null);
 
@@ -43,7 +44,7 @@ class Interpolate extends Component {
       return memo;
     }, children);
 
-    return React.createElement.apply(this, [parent, null].concat(children));
+    return React.createElement.apply(this, [parent, { className }].concat(children));
   }
 }
 


### PR DESCRIPTION
Hi. There doesn't appear to be a way to customize the `className` prop set on the parent for interpolated components. This is a very naive implementation as I'm not familiar with all of the considerations that need to be made, but I figured it'd be good enough as a starting point for a discussion.