### PR TITLE
chore: add coverage test to travis + badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,7 @@ node_js:
   - "6"
 script:
   - npm test
+after_success:
+  - npm run test:coverage
+  - cat ./coverage/lcov.info | node_modules/.bin/coveralls --verbose
+  - rm -rf ./coverage

--- a/README.md
+++ b/README.md
@@ -2,6 +2,27 @@
 
 > Higher-order components and components for React when using [i18next](https://github.com/i18next/i18next).
 
+[![NPM][npm-icon] ][npm-url]
+
+[![Travis CI][travis-ci-image] ][travis-ci-url]
+[![Coverage Status](https://coveralls.io/repos/github/i18next/react-i18next/badge.svg?branch=master)](https://coveralls.io/github/i18next/react-i18next?branch=master)
+[![Quality][quality-badge] ][quality-url]
+[![dependencies][dependencies-image] ][dependencies-url]
+[![devdependencies][devdependencies-image] ][devdependencies-url]
+
+[npm-icon]: https://nodei.co/npm/react-i18next.png?downloads=true
+[npm-url]: https://npmjs.org/package/react-i18next
+[travis-ci-image]: https://travis-ci.org/i18next/react-i18next.svg?branch=master
+[travis-ci-url]: https://travis-ci.org/i18next/react-i18next
+
+[dependencies-image]: https://david-dm.org/i18next/react-i18next.png
+[dependencies-url]: https://david-dm.org/i18next/react-i18next
+[devdependencies-image]: https://david-dm.org/i18next/react-i18next/dev-status.png
+[devdependencies-url]: https://david-dm.org/i18next/react-i18next#info=devDependencies
+
+[quality-badge]: http://npm.packagequality.com/shield/react-i18next.svg
+[quality-url]: http://packagequality.com/#?package=react-i18next
+
 ### Installation
 
 Source can be loaded via [npm](https://www.npmjs.com/package/react-i18next), bower or [downloaded](https://github.com/i18next/react-i18next/blob/master/react-i18next.min.js) from this repo.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-preset-es2015-rollup": "1.2.0",
     "babel-preset-stage-0": "6.5.0",
     "babel-register": "6.11.6",
+    "coveralls": "^2.11.12",
     "enzyme": "2.4.1",
     "eslint": "3.3.1",
     "eslint-config-airbnb": "10.0.1",


### PR DESCRIPTION
Hi, 

I have added code coverage trigger on travis after a success. Then the result of the coverage is pushed on coveralls.

I have forgotten last time to add badges to expose code quality to visitors. Here it is 

![screen shot 2016-09-08 at 15 22 48](https://cloud.githubusercontent.com/assets/19857479/18350856/2729cd06-75d8-11e6-9051-72f4ee308dbe.png)

Could you please just activate the repository on coveralls and merge this please ?