### PR TITLE
Accept i18n context from props or context in translate wrapper

### DIFF
--- a/src/translate.js
+++ b/src/translate.js
@@ -13,7 +13,7 @@ export default function translate(namespaces, options = {}) {
     class Translate extends Component {
       constructor(props, context) {
         super(props, context);
-        this.i18n = context.i18n;
+        this.i18n = context.i18n || props.i18n;
         namespaces = namespaces || this.i18n.options.defaultNS;
 
         this.state = {


### PR DESCRIPTION
Useful feature that makes using `translate` HOC easier to use without a provider.  Similar to react-redux: https://github.com/reactjs/react-redux/blob/master/src/components/connect.js#L83