### PR TITLE
README - Use js instead of json for syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ __translate(namespaces, options)__: higher-order component to wrap a translatabl
 
 options:
 
-```json
+```js
 {
   withRef: false,         // store a ref to the wrapped component
   translateFuncName: 't', // will change the name of translation prop default 't'


### PR DESCRIPTION
Since JSON does not allow comments, the syntax highlighter was acting a little weird for a block of code contained in the readme file. 

This PR fixes this, by changing the syntax highlighter language from JSON to JS. See images below.

**Before:**
![image](https://cloud.githubusercontent.com/assets/2975955/18627230/282f849a-7e5a-11e6-900b-65ed479c05ef.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/2975955/18627256/55023346-7e5a-11e6-81f0-dac95291ecbc.png)
