### PR TITLE
Suppresses required context type warning if passing i18n as a prop

### DIFF
--- a/__tests__/translate-test.js
+++ b/__tests__/translate-test.js
@@ -14,7 +14,7 @@ describe('translate', () => {
     Elem.NOT_KNOWN_REACT_STATIC = 'IS HOISTED ?';
     const wrapped = wrap(Elem);
     expect(wrapped.WrappedComponent).toBe(Elem);
-    expect(wrapped.contextTypes.i18n).toBe(React.PropTypes.object.isRequired);
+    expect(wrapped.contextTypes.i18n).toBe(React.PropTypes.object);
     expect(wrapped.childContextTypes.t).toBe(React.PropTypes.func.isRequired);
     expect(wrapped.displayName).toBe('Translate(Elem)');
     expect(wrapped.namespaces.length).toBe(2);

--- a/src/translate.js
+++ b/src/translate.js
@@ -94,7 +94,7 @@ export default function translate(namespaces, options = {}) {
     Translate.WrappedComponent = WrappedComponent;
 
     Translate.contextTypes = {
-      i18n: PropTypes.object.isRequired
+      i18n: PropTypes.object
     };
 
     Translate.childContextTypes = {


### PR DESCRIPTION
There is a new feature added to pass i18n as a prop (for example using DI) but React emits a warning (Required context type i18n is missing)
References #203 