### PR TITLE
Wait for deciding language

### DIFF
--- a/src/translate.js
+++ b/src/translate.js
@@ -40,8 +40,10 @@ export default function translate(namespaces, options = {}) {
 
         this.mounted = true;
         this.i18n.loadNamespaces(namespaces, () => {
-          if (this.mounted) this.setState({ ready: true });
-          if (wait && this.mounted) bind();
+          this.i18n.changeLanguage(this.i18n.options.lng, () => {
+            if (this.mounted) this.setState({ ready: true });
+            if (wait && this.mounted) bind();
+          })
         });
         if (!wait) bind();
       }


### PR DESCRIPTION
When use react-i18next with [i18next-browser-languageDetector](https://github.com/i18next/i18next-browser-languageDetector), My application with following options render text as fallback language while very short period.

### i18next options
```
{ fallbackLng: 'en' }
```

### react-i18next options
```
translate(['common'], { wait: true })
```

### language priority in browser
1. ja
2. en

IMHO, `wait` option should wait for deciding language by languageDetector.