### PR TITLE
Fix react-i18next to work with TypeScript

### DIFF
--- a/src/translate.js
+++ b/src/translate.js
@@ -19,9 +19,9 @@ export default function translate(namespaces, options = {}) {
         namespaces = namespaces || this.i18n.options.defaultNS;
         if (typeof namespaces === 'string') namespaces = [namespaces];
 
-        if (!wait && this.i18n.options.wait || (this.i18n.options.react && this.i18n.options.react.wait)) wait = this.i18n.options.wait || this.i18n.options.react.wait;
+        if (!wait && this.i18n.options && (this.i18n.options.wait || (this.i18n.options.react && this.i18n.options.react.wait))) wait = true;
 
-        this.nsMode = options.nsMode || (this.i18n.options.react && this.i18n.options.react.nsMode) || 'default';
+        this.nsMode = options.nsMode || (this.i18n.options && this.i18n.options.react && this.i18n.options.react.nsMode) || 'default';
 
         this.state = {
           i18nLoadedAt: null,

--- a/src/translate.js
+++ b/src/translate.js
@@ -65,6 +65,10 @@ export default function translate(namespaces, options = {}) {
             };
 
             this.i18n.on('initialized', initialized);
+
+            // In case of race condition, that 'initialized' never comes - do immediately 
+            // check ready state + if i18n is initialized.
+            setTimeout(() => !this.state.ready && this.i18n.isInitialized && ready());
           }
         });
 


### PR DESCRIPTION
There were two minor problems for react-i18next to work with TypeScript. First of all options and options.react might be undefined (on initialization). Then also it might be that if wait is set "true" in props, that there's indefinite wait if i18n doesn't get "initialized" signal through.