### PR TITLE
Do only check if component is not ready, and try set it ready

### DIFF
--- a/src/translate.js
+++ b/src/translate.js
@@ -65,10 +65,6 @@ export default function translate(namespaces, options = {}) {
             };
 
             this.i18n.on('initialized', initialized);
-
-            // In case of race condition, that 'initialized' never comes - do immediately 
-            // check ready state + if i18n is initialized.
-            setTimeout(() => !this.state.ready && this.i18n.isInitialized && ready());
           }
         });
 


### PR DESCRIPTION
Here's the example application we discussed in previous pull request:

https://github.com/jussikinnula/react-starter/tree/typescript-i18next

Actually I found out that without the extra Auth0 dependency, the i18next initialization prolongs so that even the workaround doesn't work. But I did test that if we disregard the isInitialized checking on the setTimeout, we'll get the ready state done still in the next micro interval (e.g. initilization will happen, and after that we'll set the ready state).

I did include a build of react-i18next with the patch in the example application. You can use the version 4.1.1 to see how it behaves (you'll see only white screen, until you set wait's "false").

The debug console logs I did put in use in translate.js are:
- i18next: initialized
- App.tsx: if (this.i18n.isInitialized) => this.i18n.isInitialized = undefined
- App.tsx: Before setTimeout => this.i18n.isInitialized = undefined, this.state.ready = false
- App.tsx: setTimeout runs ready() => this.mounted = true, wait = true
- Header.tsx: if (this.i18n.isInitialized) => this.i18n.isInitialized = undefined
- Header.tsx: Before setTimeout => this.i18n.isInitialized = undefined, this.state.ready = false
- Header.tsx: setTimeout runs ready() => this.mounted = true, wait = true

My best guess is that react-i18n works without any middlewares (e.g. Redux & Auth0) without the patch, but when we get more middlewares it takes longer time to initialize. And I'm basically just wondering that `this.i18n` comes from context or props, so it might actually be that React doesn't pass the correct reference until the middlewares are mounted per component.