### PR TITLE
Remove workaround to set ready if there was no initialized signal

### DIFF
--- a/src/translate.js
+++ b/src/translate.js
@@ -65,10 +65,6 @@ export default function translate(namespaces, options = {}) {
             };
 
             this.i18n.on('initialized', initialized);
-
-            // In case of race condition, that 'initialized' never comes - do immediately 
-            // check ready state + if i18n is initialized.
-            setTimeout(() => !this.state.ready && this.i18n.isInitialized && ready());
           }
         });
 


### PR DESCRIPTION
I have now tested that the problem originally (to need this workaround) was because of misuse of i18next initialization.

The updated code is at:
https://github.com/jussikinnula/react-starter/tree/typescript-i18next