### PR TITLE
Expose ES2015 modules as module in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Internationalization for react done right. Using the i18next i18n ecosystem.",
   "main": "dist/commonjs/index.js",
   "jsnext:main": "dist/es/index.js",
+  "module": "dist/es/index.js",
   "keywords": [
     "i18next",
     "internationalization",


### PR DESCRIPTION
jsnext:main is not supported in webpack (since webpack2).

For reference: https://github.com/webpack/webpack/issues/1979