### PR TITLE
Support passing i18n and t as Trans props

### DIFF
--- a/src/Trans.js
+++ b/src/Trans.js
@@ -89,32 +89,27 @@ function renderNodes(children, targetString, i18n) {
 
 export default class Trans extends React.PureComponent {
 
-  constructor(props, context) {
-    super(props, context);
-    this.i18n = props.i18n || context.i18n;
-    this.t = props.t || context.t;
-  }
-
   render() {
-    const { children, count, parent, i18nKey, ...additionalProps } = this.props;
+    const contextAndProps = { i18n: this.context.i18n, t: this.context.t, ...this.props };
+    const { children, count, parent, i18nKey, i18n, t, ...additionalProps } = contextAndProps;
 
     const defaultValue = nodesToString('', children, 0);
     const key = i18nKey || defaultValue;
-    const translation = this.t(key, { interpolation: { prefix: '#$?', suffix: '?$#' }, defaultValue, count });
+    const translation = t(key, { interpolation: { prefix: '#$?', suffix: '?$#' }, defaultValue, count });
 
-    if (this.i18n.options.react && this.i18n.options.react.exposeNamespace) {
-      let ns = typeof this.t.ns === 'string' ? this.t.ns : this.t.ns[0];
-      if (i18nKey && this.i18n.options.nsSeparator && i18nKey.indexOf(this.i18n.options.nsSeparator) > -1) {
-        const parts = i18nKey.split(this.i18n.options.nsSeparator);
+    if (i18n.options.react && i18n.options.react.exposeNamespace) {
+      let ns = typeof t.ns === 'string' ? t.ns : t.ns[0];
+      if (i18nKey && i18n.options.nsSeparator && i18nKey.indexOf(i18n.options.nsSeparator) > -1) {
+        const parts = i18nKey.split(i18n.options.nsSeparator);
         ns = parts[0];
       }
-      if (this.t.ns) additionalProps['data-i18next-options'] = JSON.stringify({ ns });
+      if (t.ns) additionalProps['data-i18next-options'] = JSON.stringify({ ns });
     }
 
     return React.createElement(
       parent,
       additionalProps,
-      renderNodes(children, translation, this.i18n)
+      renderNodes(children, translation, i18n)
     );
   }
 }
@@ -122,7 +117,9 @@ export default class Trans extends React.PureComponent {
 Trans.propTypes = {
   count: PropTypes.number,
   parent: PropTypes.string,
-  i18nKey: PropTypes.string
+  i18nKey: PropTypes.string,
+  i18n: PropTypes.object,
+  t: PropTypes.func
 };
 
 Trans.defaultProps = {

--- a/test/trans.render.spec.js
+++ b/test/trans.render.spec.js
@@ -163,3 +163,39 @@ describe('trans complex', () => {
     )).toBe(true);
   });
 });
+
+describe('trans with t as prop', () => {
+  const TestElement = ({ t, cb }) => {
+    const customT = (...args) => {
+      if (cb) cb();
+      return t(...args);
+    };
+    return (
+      <Trans i18nKey="transTest1" t={customT}>
+        Open <Link to="/msgs">here</Link>.
+      </Trans>
+    );
+  };
+
+  it('should use props t', () => {
+    let usedCustomT = false;
+    const cb = () => { usedCustomT = true; };
+
+    const HocElement = translate(['translation'], {})(TestElement);
+
+    mount(<HocElement cb={cb} />, { context });
+    expect(usedCustomT).toBe(true);
+  });
+
+  it('should not pass t to HTML element', () => {
+    const HocElement = translate(['translation'], {})(TestElement);
+
+    const wrapper = mount(<HocElement />, { context });
+    expect(wrapper.contains(
+      <div>
+        Go <Link to="/msgs">there</Link>.
+      </div>
+    )).toBe(true);
+  });
+
+});

--- a/test/trans.spec.js
+++ b/test/trans.spec.js
@@ -9,15 +9,9 @@ describe('trans', () => {
       .toBe(PropTypes.object.isRequired);
     expect(Trans.contextTypes.t)
       .toBe(PropTypes.func.isRequired);
-    const props = {};
-    const context = {
-      i18n: {},
-      t(message) {
-        return message;
-      }
-    };
-    const trans = new Trans(props, context);
-    expect(trans.i18n).toBe(context.i18n);
-    expect(trans.t).toBe(context.t);
+    expect(Trans.propTypes.i18n)
+      .toBe(PropTypes.object);
+    expect(Trans.propTypes.t)
+      .toBe(PropTypes.func);
   });
 });


### PR DESCRIPTION
Currently, Trans uses i18n and t props when provided, but also passes them down to the rendered HTML element causing an error.

This PR does the following:
- Adds i18n and t propTypes
- Moves logic that determines which i18n and t to use from constructor to render
- Ensures i18n and t props don't get passed to the HTML element