### PR TITLE
Change prop-types from a peer dependency to a normal dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   },
   "dependencies": {
     "hoist-non-react-statics": "2.3.1",
-    "html-parse-stringify2": "2.0.1"
+    "html-parse-stringify2": "2.0.1",
+    "prop-types": "^15.6.0"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",
@@ -48,7 +49,6 @@
     "jest": "21.2.1",
     "jest-cli": "21.2.1",
     "mkdirp": "0.5.1",
-    "prop-types": "^15.6.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-test-renderer": "^16.0.0",
@@ -63,7 +63,6 @@
   },
   "peerDependencies": {
     "i18next": ">= 6.0.1",
-    "prop-types": ">= 15.0.0",
     "react": ">= 15.0.0",
     "react-dom": ">= 15.0.0"
   },


### PR DESCRIPTION
Recommended by the prop-types package: https://github.com/facebook/prop-types#how-to-depend-on-this-package