### PR TITLE
Add basic test for <I18n /> component

### DIFF
--- a/test/i18n.render.spec.js
+++ b/test/i18n.render.spec.js
@@ -5,7 +5,7 @@ import I18n from '../src/I18n';
 
 const context = { i18n };
 
-describe('I18n simple', () => {
+describe('I18n', () => {
   it('should render correct content', () => {
     const wrapper = mount(
       <I18n ns="translation">{t => <span>{t('key1')}</span>}</I18n>,
@@ -13,5 +13,33 @@ describe('I18n simple', () => {
     );
 
     expect(wrapper.contains(<span>test</span>)).toBe(true);
+  });
+
+  it('should render correct content for a component that renders a <I18n /> component', () => {
+    const Comp = () => (
+      <div>
+        Values:
+        <I18n ns="translation">
+          {t => (
+            <div>
+              <span>{t('key1')}</span>
+              <span>{t('key1')}</span>
+            </div>
+          )}
+        </I18n>
+      </div>
+    );
+
+    const wrapper = mount(<Comp />, { context });
+
+    expect(
+      wrapper.contains(
+        <div>
+          Values:
+          <span>test</span>
+          <span>test</span>
+        </div>
+      )
+    ).toBe(true);
   });
 });

--- a/test/i18n.render.spec.js
+++ b/test/i18n.render.spec.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import i18n from './i18n';
+import I18n from '../src/I18n';
+
+const context = { i18n };
+
+describe('I18n simple', () => {
+  it('should render correct content', () => {
+    const wrapper = mount(
+      <I18n ns="translation">{t => <span>{t('key1')}</span>}</I18n>,
+      { context }
+    );
+
+    expect(wrapper.contains(<span>test</span>)).toBe(true);
+  });
+});


### PR DESCRIPTION
The component appeared to have some test coverage but was not directly
tested. This suite can be expanded to include more tests.

Aside: I've been trying to get my project's tests working for components that use `<I18n />` and have not had any luck so far. When I checked the `react-i18next` repo to see if it had any tests for this, I couldn't find any so decided to write one. I might provide another PR with some more advanced tests as I start to debug my own project.

Thanks.