### PR TITLE
Remove i18n prop from <I18n /> tests

### DIFF
--- a/test/i18n.render.spec.js
+++ b/test/i18n.render.spec.js
@@ -8,7 +8,7 @@ const context = { i18n };
 describe.only('I18n', () => {
   it('should render correct content', () => {
     const wrapper = mount(
-      <I18n i18n={i18n} ns="translation">{t => <span>{t('key1')}</span>}</I18n>,
+      <I18n ns="translation">{t => <span>{t('key1')}</span>}</I18n>,
       { context }
     );
 
@@ -19,7 +19,7 @@ describe.only('I18n', () => {
     const Comp = () => (
       <div>
         Values:
-        <I18n i18n={i18n} ns="translation">
+        <I18n ns="translation">
           {t => (
             <div>
               <span>{t('key1')}</span>


### PR DESCRIPTION
The prop should not need to be passed to get this work.

See https://react.i18next.com/components/i18n-render-prop.html. You don't have to pass the prop in an app to get the render prop to work, so I'm not sure why you have to pass it in the test.

Thus, passing the prop in the test is actually a false positive.

@jamuhl correct me if I'm wrong, but I don't think your commit actually fixes the problem, it just silences the test: https://github.com/i18next/react-i18next/commit/0cd849d7070335adbaf508db34e945365ddf6448#diff-798d3ecb9f34ff4cd22a54a7e848c0f5R22

