### PR TITLE
Use t from I18n if not present in context

### DIFF
--- a/src/Trans.js
+++ b/src/Trans.js
@@ -96,7 +96,8 @@ export default class Trans extends React.Component {
 
   render() {
     const contextAndProps = { i18n: this.context.i18n, t: this.context.t, ...this.props };
-    const { children, count, parent, i18nKey, i18n, t, ...additionalProps } = contextAndProps;
+    const { children, count, parent, i18nKey, i18n, t: tFromContextAndProps, ...additionalProps } = contextAndProps;
+    const t = tFromContextAndProps || i18n.t.bind(i18n);
 
     const reactI18nextOptions = (i18n.options && i18n.options.react) || {};
     const useAsParent = parent !== undefined ? parent : reactI18nextOptions.defaultTransParent;
@@ -138,6 +139,5 @@ Trans.propTypes = {
 // };
 
 Trans.contextTypes = {
-  i18n: PropTypes.object.isRequired,
-  t: PropTypes.func.isRequired
+  i18n: PropTypes.object.isRequired
 };

--- a/test/trans.render.spec.js
+++ b/test/trans.render.spec.js
@@ -3,6 +3,7 @@ import { shallow, render, mount } from 'enzyme';
 import i18n from './i18n';
 import translate from '../src/translate';
 import Trans from '../src/Trans';
+import PropTypes from "prop-types";
 
 const context = {
   i18n
@@ -67,6 +68,16 @@ describe('trans simple', () => {
       <span>
         Go <Link to="/msgs">there</Link>.
       </span>
+    )).toBe(true);
+  });
+
+  it('uses the i18n.t function if t is not in the context nor specified using props', () => {
+    const wrapper = mount(<TestElement />, { context, childContextTypes: { i18n: PropTypes.object.isRequired } });
+
+    expect(wrapper.contains((
+      <div>
+        Go <Link to="/msgs">there</Link>.
+      </div>)
     )).toBe(true);
   });
 });

--- a/test/trans.spec.js
+++ b/test/trans.spec.js
@@ -7,8 +7,6 @@ describe('trans', () => {
   it('should have some stuff', () => {
     expect(Trans.contextTypes.i18n)
       .toBe(PropTypes.object.isRequired);
-    expect(Trans.contextTypes.t)
-      .toBe(PropTypes.func.isRequired);
     expect(Trans.propTypes.i18n)
       .toBe(PropTypes.object);
     expect(Trans.propTypes.t)


### PR DESCRIPTION
Use `i18n.t` in the Trans component if `t` is not set with props or present in the context.
This allows to use Trans with the I18nextProvider.

Fixes #352 