### PR TITLE
Add renderNullWhileWaiting option

### DIFF
--- a/src/I18n.js
+++ b/src/I18n.js
@@ -112,7 +112,7 @@ export default class I18n extends Component {
     const { children } = this.props;
     const { ready } = this.state;
 
-    if (!ready && this.options.wait && this.options.renderNullWhileWaiting) return null;
+    if (!ready && this.options.wait) return null;
 
     // remove ssr flag set by provider - first render was done from now on wait if set to wait
     if (this.i18n.options && this.i18n.options.isInitialSSR && !removedIsInitialSSR) {
@@ -122,12 +122,11 @@ export default class I18n extends Component {
       }, 100);
     }
 
-    const ctx = {
+    return children(this.t, {
       i18n: this.i18n,
       t: this.t,
-      ...(this.options.wait && !this.options.renderNullWhileWaiting) ? { ready } : {}
-    };
-    return children(this.t, ctx);
+      ready
+    });
   }
 }
 

--- a/src/I18n.js
+++ b/src/I18n.js
@@ -112,7 +112,7 @@ export default class I18n extends Component {
     const { children } = this.props;
     const { ready } = this.state;
 
-    if (!ready && this.options.wait) return null;
+    if (!ready && this.options.wait && this.options.renderNullWhileWaiting) return null;
 
     // remove ssr flag set by provider - first render was done from now on wait if set to wait
     if (this.i18n.options && this.i18n.options.isInitialSSR && !removedIsInitialSSR) {
@@ -122,7 +122,12 @@ export default class I18n extends Component {
       }, 100);
     }
 
-    return children(this.t, { i18n: this.i18n, t: this.t });
+    const ctx = {
+      i18n: this.i18n,
+      t: this.t,
+      ...(this.options.wait && !this.options.renderNullWhileWaiting) ? { ready } : {}
+    };
+    return children(this.t, ctx);
   }
 }
 

--- a/src/I18n.js
+++ b/src/I18n.js
@@ -32,10 +32,7 @@ export default class I18n extends Component {
     const language = this.i18n.languages && this.i18n.languages[0];
     const ready = !!language && this.namespaces.every(ns => this.i18n.hasResourceBundle(language, ns));
 
-    this.state = {
-      i18nLoadedAt: null,
-      ready
-    };
+    this.state = { ready };
 
     this.onI18nChanged = this.onI18nChanged.bind(this);
     this.getI18nTranslate = this.getI18nTranslate.bind(this);
@@ -101,7 +98,6 @@ export default class I18n extends Component {
     if (!this.mounted) return;
 
     this.t = this.getI18nTranslate();
-    this.setState({ i18nLoadedAt: new Date() });
   }
 
   getI18nTranslate() {

--- a/src/context.js
+++ b/src/context.js
@@ -1,5 +1,6 @@
 let defaultOptions = {
   wait: false,
+  renderNullWhileWaiting: true,
   withRef: false,
   bindI18n: 'languageChanged loaded',
   bindStore: 'added removed',

--- a/src/context.js
+++ b/src/context.js
@@ -1,6 +1,5 @@
 let defaultOptions = {
   wait: false,
-  renderNullWhileWaiting: true,
   withRef: false,
   bindI18n: 'languageChanged loaded',
   bindStore: 'added removed',

--- a/src/translate.js
+++ b/src/translate.js
@@ -66,10 +66,10 @@ export default function translate(namespaceArg, options = {}) {
           (t, { ready, ...context }) => React.createElement(
             WrappedComponent,
             {
+              tReady: ready,
               ...this.props,
               ...extraProps,
-              ...context,
-              ...(ready === undefined ? {} : { tReady: ready })
+              ...context
             }
           )
         );

--- a/src/translate.js
+++ b/src/translate.js
@@ -63,9 +63,14 @@ export default function translate(namespaceArg, options = {}) {
         return React.createElement(
           I18n,
           { ns: this.namespaces, ...this.options, ...this.props, ...{ i18n: this.i18n } },
-          (t, context) => React.createElement(
+          (t, { ready, ...context }) => React.createElement(
             WrappedComponent,
-            { ...this.props, ...extraProps, ...context }
+            {
+              ...this.props,
+              ...extraProps,
+              ...context,
+              ...(ready === undefined ? {} : { tReady: ready })
+            }
           )
         );
       }

--- a/test/translate.render.wait.spec.js
+++ b/test/translate.render.wait.spec.js
@@ -21,10 +21,10 @@ const context = {
   i18n: newI18n
 };
 
-describe.only('translate wait', () => {
-  const TestElement = ({ t }) => {
+describe('translate wait', () => {
+  const TestElement = ({ t, tReady }) => {
     return (
-      <div>{t('key1')}</div>
+      <div>{tReady === false ? 'loading' : t('key1')}</div>
     );
   }
 
@@ -53,6 +53,21 @@ describe.only('translate wait', () => {
     const wrapper = mount(<HocElement />, { context });
     // console.log(wrapper.debug());
     expect(wrapper.contains(<div>test</div>)).toBe(false);
+
+    backend.flush();
+    wrapper.update();
+
+    setTimeout(() => {
+      expect(wrapper.contains(<div>test</div>)).toBe(true);
+    }, 50);
+  });
+
+  it('should not wait for correct translation', () => {
+    const HocElement = translate(['common'], { wait: true, renderNullWhileWaiting: false })(TestElement);
+
+    const wrapper = mount(<HocElement />, { context });
+    // console.log(wrapper.debug());
+    expect(wrapper.contains(<div>loading</div>)).toBe(true);
 
     backend.flush();
     wrapper.update();

--- a/test/translate.render.wait.spec.js
+++ b/test/translate.render.wait.spec.js
@@ -22,7 +22,7 @@ const context = {
 };
 
 describe('translate wait', () => {
-  const TestElement = ({ t, tReady }) => {
+  const TestElement = ({ t }) => {
     return (
       <div>{t('key1')}</div>
     );

--- a/test/translate.render.wait.spec.js
+++ b/test/translate.render.wait.spec.js
@@ -24,7 +24,7 @@ const context = {
 describe('translate wait', () => {
   const TestElement = ({ t, tReady }) => {
     return (
-      <div>{tReady === false ? 'loading' : t('key1')}</div>
+      <div>{t('key1')}</div>
     );
   }
 
@@ -53,21 +53,6 @@ describe('translate wait', () => {
     const wrapper = mount(<HocElement />, { context });
     // console.log(wrapper.debug());
     expect(wrapper.contains(<div>test</div>)).toBe(false);
-
-    backend.flush();
-    wrapper.update();
-
-    setTimeout(() => {
-      expect(wrapper.contains(<div>test</div>)).toBe(true);
-    }, 50);
-  });
-
-  it('should not wait for correct translation', () => {
-    const HocElement = translate(['common'], { wait: true, renderNullWhileWaiting: false })(TestElement);
-
-    const wrapper = mount(<HocElement />, { context });
-    // console.log(wrapper.debug());
-    expect(wrapper.contains(<div>loading</div>)).toBe(true);
 
     backend.flush();
     wrapper.update();


### PR DESCRIPTION
Only would need to document the new option - if `waiting` is set to true, and we are not rendering `null`, we pass a `ready` flag to the children of `I18next`. If we're using the HoC, then in order to prevent naming clashes, rename `ready` as `tReady` and pass it as a prop to the `WrappedComponent`