### PR TITLE
Fix reference to props in constructor

### DIFF
--- a/src/I18n.js
+++ b/src/I18n.js
@@ -9,7 +9,7 @@ export default class I18n extends Component {
     super(props, context);
 
     this.i18n = props.i18n || context.i18n || getI18n();
-    this.namespaces = this.props.ns || (this.i18n.options && this.i18n.options.defaultNS);
+    this.namespaces = props.ns || (this.i18n.options && this.i18n.options.defaultNS);
     if (typeof this.namespaces === 'string') this.namespaces = [this.namespaces];
 
     const i18nOptions = (this.i18n && this.i18n.options && this.i18n.options.react) || {};


### PR DESCRIPTION
In <=IE10, `this.props` is null, so when attempting to set the namespaces,
the reference to `this.props.ns` raises an exception. By updating the
reference to use the version passed into the constructor, we are
consistent with other usages of props on the constructor, and I've
confirmed this patch works in <=IE10 as well.