### PR TITLE
Allow to pass a function as parent for <Trans /> component

### DIFF
--- a/src/Trans.js
+++ b/src/Trans.js
@@ -131,7 +131,7 @@ export default class Trans extends React.Component {
 
 Trans.propTypes = {
   count: PropTypes.number,
-  parent: PropTypes.node,
+  parent: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   i18nKey: PropTypes.string,
   i18n: PropTypes.object,
   t: PropTypes.func


### PR DESCRIPTION
Currently if you pass something different than ReactNode to `parent` prop, `propTypes` validation throws an error:

```
Warning: Failed prop type: Invalid prop `parent` supplied to `Trans`, expected a ReactNode.
```

This would happen if  you use `glamorousComponent` for example.

```js
// RenderedComponent.js

<Trans
  i18nkey='common.myTransKey'
  parent={Text}
  dynamicVal={dynamicVal}
>
  My <strong>interpolation</strong> and this is my <i>{{dynamicVal}}</i>
</Trans>

// Text.js

export const Text = glamorous.p({
  fontSize: 16,
  marginTop: 10
})
```