### PR TITLE
In Trans.js, set default value to undefined as last possible option

### DIFF
--- a/src/Trans.js
+++ b/src/Trans.js
@@ -105,7 +105,7 @@ export default class Trans extends React.Component {
     const reactI18nextOptions = (i18n.options && i18n.options.react) || {};
     const useAsParent = parent !== undefined ? parent : reactI18nextOptions.defaultTransParent;
 
-    const defaultValue = defaults || nodesToString('', children, 0);
+    const defaultValue = defaults || nodesToString('', children, 0) || undefined;
     const hashTransKey = reactI18nextOptions.hashTransKey;
     const key = i18nKey || (hashTransKey ? hashTransKey(defaultValue) : defaultValue);
     const interpolationOverride = values ? {} : { interpolation: { prefix: '#$?', suffix: '?$#' } };


### PR DESCRIPTION
Using Trans component, if node is left empty, default value is set to a empty string. I18next will use that default value instead of its fallback mechanism. By setting the default value to undefined will let i18next define what fallback to use.