### PR TITLE
Don't require `i18n` in context

### DIFF
--- a/src/Trans.js
+++ b/src/Trans.js
@@ -143,6 +143,6 @@ Trans.propTypes = {
 // };
 
 Trans.contextTypes = {
-  i18n: PropTypes.object.isRequired,
+  i18n: PropTypes.object,
   t: PropTypes.func
 };

--- a/test/trans.spec.js
+++ b/test/trans.spec.js
@@ -6,7 +6,7 @@ import Trans from '../src/Trans';
 describe('trans', () => {
   it('should have some stuff', () => {
     expect(Trans.contextTypes.i18n)
-      .toBe(PropTypes.object.isRequired);
+      .toBe(PropTypes.object);
     expect(Trans.propTypes.i18n)
       .toBe(PropTypes.object);
     expect(Trans.propTypes.t)


### PR DESCRIPTION
Since it can be passed in as a prop, we shouldn't require it to be present in context.

Fixes #473.