### PR TITLE
Don't polyfill Object.entries globally

### DIFF
--- a/src/loadNamespaces.js
+++ b/src/loadNamespaces.js
@@ -1,6 +1,5 @@
-// shim object entries
-if (!Object.entries)
-  Object.entries = function( obj ){
+const objectEntries = Object.entries ||
+  function( obj ){
     var ownProps = Object.keys( obj ),
         i = ownProps.length,
         resArray = new Array(i); // preallocate the Array
@@ -14,7 +13,7 @@ if (!Object.entries)
 function eachComponents(components, iterator) {
   for (let i = 0, l = components.length; i < l; i++) { // eslint-disable-line id-length
     if (typeof components[i] === 'object') {
-      for (const [key, value] of Object.entries(components[i])) {
+      for (const [key, value] of objectEntries(components[i])) {
         iterator(value, i, key);
       }
     } else {


### PR DESCRIPTION
Patching `Object.entries` affects other code beyond this library, which
ideally should not happen. With this patch the polyfill is still used
when necessary but the global environment is not unexpectedly changed by
including react-i18next :)