### PR TITLE
Skipped custom html tags

### DIFF
--- a/src/Trans.js
+++ b/src/Trans.js
@@ -75,8 +75,11 @@ function renderNodes(children, targetString, i18n) {
             inner
           ));
         } else if (typeof child === 'object' && !isElement) {
-          const interpolated = i18n.services.interpolator.interpolate(node.children[0].content, child, i18n.language);
-          mem.push(interpolated);
+          const content = node.children[0] ? node.children[0].content : null
+          if (content) {
+            const interpolated = i18n.services.interpolator.interpolate(node.children[0].content, child, i18n.language);
+            mem.push(interpolated);
+          }
         } else {
           mem.push(child);
         }

--- a/test/i18n.js
+++ b/test/i18n.js
@@ -14,6 +14,7 @@ i18n
           interpolateKey2: '<strong>add</strong> {{insert}} {{up, uppercase}}',
           transTest1: "Go <1>there</1>.",
           transTest1_noParent: "<0>Go <1>there</1>.</0>",
+          transTest1_customHtml: "Go <br/><1>there</1>.",
           transTest2: "Hello <1><0>{{name}}</0></1>, you have <3>{{count}}</3> message. Open <5>hear</5>.",
           transTest2_plural: "Hello <1><0>{{name}}</0></1>, you have <3>{{count}}</3> messages. Open <5>here</5>.",
           testTransKey1: "<0>{{numOfItems}}</0> item matched.",

--- a/test/trans.render.spec.js
+++ b/test/trans.render.spec.js
@@ -105,6 +105,29 @@ describe('trans simple using ns prop', () => {
   });
 });
 
+describe('trans simple with custom html tag', () => {
+  const TestElement = ({ t, parent }) => {
+    return (
+      <Trans i18nKey="transTest1_customHtml" parent={parent}>
+        Open <Link to="/msgs">here</Link>.
+      </Trans>
+    );
+  }
+  
+  it('should skip custom html tags', () => {
+    const HocElement = translate(['translation'], {})(TestElement);
+
+    const wrapper = mount(<HocElement />, { context });
+    // console.log(wrapper.debug());
+    expect(wrapper.contains(
+      <div>
+        Go <Link to="/msgs">there</Link>.
+      </div>
+    )).toBe(true);
+  });
+
+})
+
 describe('trans testTransKey1 singular', () => {
   const TestElement = ({ t }) => {
     const numOfItems = 1;


### PR DESCRIPTION
## Description

Fixed the bug, with empty html tags in source for Trans component. 
Translators can (yes, they can) add some html tag into translations.

For example we had source 
```js
{
 "key" : "Some text <1>other text<1>"
}
```

But translations manager decide to add some tags in translations:
`"Some text <br /> <1>other text<1>"`

After that react-i18next throw the error

```
    TypeError: Cannot read property 'content' of undefined

      at src/Trans.js:78:86
          at Array.reduce (<anonymous>)
```
