### PR TITLE
Use JSX syntaxe hightlight in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The documentation is published on [react.i18next.com](https://react.i18next.com)
 
 **Before:** Your react code would have looked something like:
 
-```html
+```jsx
 ...
 <div>Just simple content</div>
 <div>
@@ -39,7 +39,7 @@ The documentation is published on [react.i18next.com](https://react.i18next.com)
 
 **After:** With the trans component just change it to:
 
-```html
+```jsx
 ...
 <div>{t('simpleContent')}</div>
 <Trans i18nKey="userMessagesUnread" count={count}>


### PR DESCRIPTION
To prevent ugly red squares in code examples, the used language for syntaxe highlight should be changed