### PR TITLE
related to issue #504: also report default Namespace with translate()

### DIFF
--- a/src/translate.js
+++ b/src/translate.js
@@ -29,7 +29,7 @@ export default function translate(namespaceArg, options = {}) {
         this.options = { ...getDefaults(), ...i18nOptions, ...options };
 
         if (context.reportNS) {
-          const namespaces = Array.isArray(namespaceArg) ? namespaceArg : [namespaceArg];
+          const namespaces = this.namespaces || [undefined];
           namespaces.forEach(context.reportNS);
         }
 

--- a/test/translate.spec.js
+++ b/test/translate.spec.js
@@ -122,7 +122,17 @@ describe('translate', () => {
     expect(instance.namespaces.length).toBe(1);
     expect(instance.namespaces[0]).toBe('i18nDefaultNS');
   });
-  it('should report namespaces', () => {
+  it('should report a single used namespace to an array', () => {
+    const namespaces = [];
+    const C = translate('ns1')(<div>text</div>);
+    shallow(<C />, {
+      context: {
+        reportNS: ns => namespaces.push(ns)
+      }
+    });
+    expect(namespaces).toEqual(['ns1']);
+  });
+  it('should report multiple used namespaces to an array', () => {
     const namespaces = [];
     const C = translate(['ns1', 'ns2'])(<div>text</div>);
     shallow(<C />, {
@@ -131,5 +141,38 @@ describe('translate', () => {
       }
     });
     expect(namespaces).toEqual(['ns1', 'ns2']);
+  });
+  it('should report undefined if no namespace used and no default namespace defined', () => {
+    const i18n = {
+      options: {},
+    };
+    translate.setI18n(i18n);
+
+    const namespaces = [];
+    const C = translate()(<div>text</div>);
+    shallow(<C />, {
+      context: {
+        reportNS: ns => namespaces.push(ns)
+      }
+    });
+    expect(namespaces).toEqual([undefined]);
+  });
+  it('should report default namespace if no namespace used', () => {
+    const i18n = {
+      options: {
+        defaultNS: 'defaultNS'
+      },
+    };
+    translate.setI18n(i18n);
+
+    const namespaces = [];
+    const C = translate()(<div>text</div>);
+    shallow(<C />, {
+      context: {
+        reportNS: ns => namespaces.push(ns)
+      }
+    });
+
+    expect(namespaces).toEqual(['defaultNS']);
   });
 });


### PR DESCRIPTION
I also chose to report `undefined` when no namespace is used with `translate()` and no default namespace is defined in options.