### PR TITLE
related to issue #508: react_i18n object property

### DIFF
--- a/src/I18n.js
+++ b/src/I18n.js
@@ -124,6 +124,9 @@ export default class I18n extends Component {
     return children(this.t, {
       i18n: this.i18n,
       t: this.t,
+      react_i18n: {
+        language: this.i18n.language,
+      },
       ready
     });
   }


### PR DESCRIPTION
This PR relates to #508 . It gives ability to compare `language` prop with the prevProps or nextProps in the react lifecycle hooks.

I thought it'd be better to pass `react_i18n` object property (which contains language) instead of raw `language` because it can be used in the future for other needs.
