### PR TITLE
Improve typings for HOC's and fix imports

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -76,6 +76,7 @@ export function withNamespaces(
 export const translate: typeof withNamespaces;
 
 export interface NamespacesConsumerProps extends ReactI18NextOptions {
+  ns: Namespace;
   initialI18nStore?: {};
   initialLanguage?: string;
   children(

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,10 @@
 import * as React from 'react';
-import i18next, {
+import {
+  i18n,
   TranslationFunction,
   ReactOptions as I18nOptions,
 } from 'i18next';
-import createReactContext, {
-  Context as ReactContext,
-} from 'create-react-context';
+import { Context as ReactContext } from 'create-react-context';
 
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 type Subtract<T, K> = Omit<T, keyof K>;
@@ -14,8 +13,6 @@ export interface ReactI18NextOptions extends I18nOptions {
   usePureComponent?: boolean;
   omitBoundRerender?: boolean;
 }
-
-type i18n = i18next.i18n;
 
 interface ReactI18nextModule {
   type: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,9 @@ import createReactContext, {
   Context as ReactContext,
 } from 'create-react-context';
 
+type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+type Subtract<T, K> = Omit<T, keyof K>;
+
 export interface ReactI18NextOptions extends I18nOptions {
   usePureComponent?: boolean;
   omitBoundRerender?: boolean;
@@ -44,8 +47,8 @@ export interface WithI18n extends I18nContextValues {
 }
 
 export function withI18n(): <P extends object>(
-  Wrapper: React.ComponentType<P & WithI18n>,
-) => React.ComponentType<P>;
+  Wrapper: React.ComponentType<P>,
+) => React.ComponentType<Subtract<P, WithI18n>>;
 
 export interface WithNamespaces extends WithI18n {
   tReady: boolean;
@@ -64,9 +67,9 @@ export interface WithNamespacesOptions extends ReactI18NextOptions {
 export function withNamespaces(
   namespace?: string,
   options?: WithNamespacesOptions,
-): <P extends object>(
-  component: React.ComponentType<P & WithNamespaces>,
-) => React.ComponentType<P>;
+): <P extends WithNamespaces>(
+  component: React.ComponentType<P>,
+) => React.ComponentType<Subtract<P, WithNamespaces>>;
 
 export const translate: typeof withNamespaces;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -61,8 +61,13 @@ export interface WithNamespacesOptions extends ReactI18NextOptions {
     | React.RefObject<HTMLElement | SVGElement | React.Component>;
 }
 
+type Namespace = string | string[];
+interface NamespaceExtractor {
+  (props: any & { namespace: Namespace }): Namespace;
+}
+
 export function withNamespaces(
-  namespace?: string,
+  namespace?: Namespace | NamespaceExtractor,
   options?: WithNamespacesOptions,
 ): <P extends WithNamespaces>(
   component: React.ComponentType<P>,

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.0.0",
     "@types/i18next": "^11.9.0",
+    "@types/react": "^16.4.18",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "10.0.1",
     "babel-jest": "23.6.0",


### PR DESCRIPTION
Closes: #565 #563 #562 #568 #571 

 - Fixed namespace type def and for when a extractor function is provided
 - Removed unneeded default imports
 - Improved types for hoc's