### PR TITLE
nextjs example page3 ssr rendering fix

### DIFF
--- a/example/nextjs/pages/_app.js
+++ b/example/nextjs/pages/_app.js
@@ -31,8 +31,22 @@ if (enableSubpaths) {
 // Warning: Did not expect server HTML to contain a <h1> in <div>.
 // not sure - did neither find something wrong - nor seems the warning to make sense
 export default class MyApp extends App {
+
+  static async getInitialProps({Component, router, ctx}) {
+    let pageProps = {};
+
+    if (Component.getInitialProps) {
+      pageProps = await Component.getInitialProps(ctx);
+    }
+
+    // initialI18nStore and initialLanguage need to be passed into NamespacesConsumer
+    // for any page that is not wrapped with withI18next to enable ssr localized rendering
+    let i18nProps = i18n.getInitialProps(ctx.req, "common");
+    return {pageProps, i18nProps};
+  }
+
   render() {
-    const { Component, pageProps } = this.props;
+    const { Component, pageProps, i18nProps } = this.props;
 
     return (
       <Container>
@@ -41,6 +55,8 @@ export default class MyApp extends App {
           ns="common"
           i18n={(pageProps && pageProps.i18n) || i18n}
           wait={process.browser}
+          initialI18nStore={i18nProps.initialI18nStore}
+          initialLanguage={i18nProps.initialLanguage}
         >
           {t => (
             <React.Fragment>


### PR DESCRIPTION
This fixes the nextjs example page 3 which currently only shows default language during ssr.
Fixes https://github.com/i18next/react-i18next/issues/574