### PR TITLE
Restore tOptions typing needed for the ICU plugin

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -100,12 +100,17 @@ export interface I18nextProviderProps {
 
 export const I18nextProvider: React.ComponentClass<I18nextProviderProps>;
 
+export interface TOptions {
+  [key: string]: any;
+}
+
 export interface TransProps {
   i18nKey?: string;
   count?: number;
   parent?: React.ReactNode;
   i18n?: i18n;
   t?: TranslationFunction;
+  tOptions?: TOptions;
   defaults?: string;
   values?: {};
   components?: React.ReactNode[];


### PR DESCRIPTION
This PR restores `tOptions` prop, which was lost while migrating from DefinitelyTypes typings. See https://github.com/i18next/react-i18next/pull/557 and https://github.com/DefinitelyTyped/DefinitelyTyped/pull/29945 (file ` types/react-i18next/src/trans.d.ts`).

cc @schettino