### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,27 @@ Want to learn more about how seamless your internationalization and translation 
 
 [watch the video](https://www.youtube.com/watch?v=9NOzJhgmyQE)
 
+### Using TypeScript & @withNamespaces()
+
+To help you using TypeScript and the @withNamespaces decorator here is a trival example
+```
+import * as React from 'react';
+import { withNamespaces, WithNamespaces } from 'react-i18next';
+
+class MyComponent extends React.PureComponent<WithNamespaces> {
+  public render() {
+    const { t } = this.props;
+    return (
+      <React.Fragment>
+        <span>{t('my-component-content')}</span>
+      </React.Fragment>
+    );
+  }
+}
+export default withNamespaces()(MyComponent);
+```
+
+
 ### Installation
 
 Source can be loaded via [npm](https://www.npmjs.com/package/react-i18next) or [downloaded](https://github.com/i18next/react-i18next/blob/master/react-i18next.min.js) from this repo.


### PR DESCRIPTION
It's not currently obvious as to how to use the `@withNamespaces` decorator in Typescript unless you manage to find the PR that introduces that support. Putting it into the readme will save others a deal of frustration