### PR TITLE
Warn if i18next instance is a promise

### DIFF
--- a/src/NamespacesConsumer.js
+++ b/src/NamespacesConsumer.js
@@ -19,6 +19,17 @@ export class NamespacesConsumerComponent extends Component {
       );
     }
 
+    if (typeof props.i18n.then === 'function') {
+      this.state = {
+        i18nLoadedAt: null,
+        ready: false,
+      };
+
+      return warnOnce(
+        'Detected a promise instead of an i18next instance. Probably you passed the return value of the i18next.init() function, this is not possible anymore with v13 of i18next. Just pass in the i18next instance directly.'
+      );
+    }
+
     // nextjs / SSR: getting data from next.js or other ssr stack
     initSSR(props);
 


### PR DESCRIPTION
Add a warning that is triggered if the new v13 of i18next is used without being aware of the [breaking changes](https://github.com/i18next/i18next/blob/master/CHANGELOG.md#1300).
This should offer a faster feedback loop.