### PR TITLE
[Typescript] Fix HOC problem when picking props from WithNamespaces interface

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -64,7 +64,7 @@ interface NamespaceExtractor {
 export function withNamespaces(
   namespace?: Namespace | NamespaceExtractor,
   options?: WithNamespacesOptions
-): <P extends WithNamespaces>(
+): <P extends Partial<WithNamespaces>>(
   component: React.ComponentType<P>
 ) => React.ComponentType<Subtract<P, WithNamespaces>>;
 

--- a/test/typescript/partial-with-namespace-pick.test.tsx
+++ b/test/typescript/partial-with-namespace-pick.test.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+import { WithNamespaces, withNamespaces } from "../../src";
+
+interface IProps extends Pick<WithNamespaces, "t"> {
+  translationKey: string;
+}
+
+// translation function t can be partially picked from WithNamespaces interface
+// so that not everything needs to be passed into the component when writing tests for it
+function MyComponent({ t, translationKey }: IProps) {
+    return <div>{t(translationKey)}</div>;
+}
+
+const MyComponentWrapped = withNamespaces()(MyComponent);
+
+function App() {
+  return <MyComponentWrapped translationKey="some-translation-key" />;
+}


### PR DESCRIPTION
When writing my components in, I do not want to declare all props that the `withNamespaces` HOC can pass into my components as required.

The problem is demonstrated in the `test/typescript/partial-with-namespace-pick.test.tsx` file that I added.
In this case, I want to get the `t` function from the HOC and also want to pass some other props into the component. But since I don't need (and don't want to mock in tests) properties like `i18n` and `tReady` that are provided by the HOC, I don't want to declare them on the component's props.

Before the test, the error was

```
test/typescript/partial-with-namespace-pick.test.tsx:14:33 - error TS2345: Argument of type '({ t, translationKey }: IProps) => Element' is not assignable to parameter of type 'ComponentType<WithNamespaces>'.
  Type '({ t, translationKey }: IProps) => Element' is not assignable to type 'FunctionComponent<WithNamespaces>'.
    Types of parameters '__0' and 'props' are incompatible.
      Property 'translationKey' is missing in type 'WithNamespaces & { children?: ReactNode; }' but required in type 'IProps'.

 export default withNamespaces()(MyComponent);
                                 ~~~~~~~~~~~

  test/typescript/partial-with-namespace-pick.test.tsx:6:3
       translationKey: string;
       ~~~~~~~~~~~~~~
    'translationKey' is declared here.
```