### PR TITLE
Update the example to respond Expo 32.0.0

### DIFF
--- a/example/reactnative-expo/App.js
+++ b/example/reactnative-expo/App.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { withNamespaces } from 'react-i18next';
-import { createStackNavigator } from 'react-navigation';
+import { createStackNavigator, createAppContainer } from 'react-navigation';
 import i18n from './js/i18n';
 import Home from './js/pages/Home';
 import Page2 from './js/pages/Page2';
@@ -12,11 +12,17 @@ const Stack = createStackNavigator({
 
 // Wrapping a stack with translation hoc asserts we get new render on language change
 // the hoc is set to only trigger rerender on languageChanged
-const WrappedStack = ({ t }) => <Stack screenProps={{ t }} />;
+class WrappedStack extends React.Component {
+  static router = Stack.router;
+  render() {
+    const { t } = this.props;
+    return <Stack screenProps={{ t }} {...this.props} />;
+  }
+}
 const ReloadAppOnLanguageChange = withNamespaces('common', {
   bindI18n: 'languageChanged',
   bindStore: false,
-})(WrappedStack);
+})(createAppContainer(WrappedStack));
 
 // The entry point using a react navigation stack navigation
 // gets wrapped by the I18nextProvider enabling using translations

--- a/example/reactnative-expo/app.json
+++ b/example/reactnative-expo/app.json
@@ -4,7 +4,7 @@
     "description": "This project is really great.",
     "slug": "reactNativeExpo",
     "privacy": "public",
-    "sdkVersion": "31.0.0",
+    "sdkVersion": "32.0.0",
     "platforms": ["ios", "android"],
     "version": "1.0.0",
     "orientation": "portrait",

--- a/example/reactnative-expo/package.json
+++ b/example/reactnative-expo/package.json
@@ -9,12 +9,12 @@
     "eject": "expo eject"
   },
   "dependencies": {
-    "expo": "^31.0.4",
+    "expo": "^32.0.0",
     "expo-localization": "^1.0.0",
     "i18next": "11.9.0",
     "react": "16.5.0",
-    "react-i18next": "8.0.6",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-31.0.1.tar.gz",
-    "react-navigation": "^2.18.2"
+    "react-i18next": "9.0.2",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-32.0.0.tar.gz",
+    "react-navigation": "^3.0.9"
   }
 }


### PR DESCRIPTION
This is the PR to respond the ver up of Expo 32.

Now react-navigation v3 is available then I needed to use `createAppContainer ` with `WrappedStack`.