### PR TITLE
hooks variant Trans props and useTranslation typings

### DIFF
--- a/hooks.d.ts
+++ b/hooks.d.ts
@@ -1,29 +1,32 @@
-import i18next from 'i18next'
-import * as React from 'react'
-import { Namespace, ReactI18NextOptions, TransProps } from './src/index'
+import i18next from 'i18next';
+import * as React from 'react';
+import { Namespace, ReactI18NextOptions, TransProps } from './src/index';
 
 interface HooksTransProps extends TransProps {
-  children: React.ReactElement<any>[]
-  tOptions: {}
-  ns: Namespace
+  children: React.ReactElement<any>[];
+  tOptions?: {};
+  ns?: Namespace;
 }
-export function setDefaults(options: ReactI18NextOptions): void
-export function getDefaults(): ReactI18NextOptions
-export function addUsedNamespaces(namespaces: Namespace[]): void
-export function getUsedNamespaces(): string[]
-export function setI18n(instance: i18next.i18n): void
-export function getI18n(): i18next.i18n
+interface UseTranslationOptions {
+  i18n?: i18next.i18n;
+}
+export function setDefaults(options: ReactI18NextOptions): void;
+export function getDefaults(): ReactI18NextOptions;
+export function addUsedNamespaces(namespaces: Namespace[]): void;
+export function getUsedNamespaces(): string[];
+export function setI18n(instance: i18next.i18n): void;
+export function getI18n(): i18next.i18n;
 export const initReactI18next: {
-  type: string
-  init(instance: i18next.i18n): void
-}
-export function composeInitialProps(ForComponent: any): (ctx: unknown) => Promise<any>
+  type: string;
+  init(instance: i18next.i18n): void;
+};
+export function composeInitialProps(ForComponent: any): (ctx: unknown) => Promise<any>;
 export function getInitialProps(): {
   initialI18nStore: {
-    [ns: string]: {}
-  }
-  initialLanguage: string
-}
+    [ns: string]: {};
+  };
+  initialLanguage: string;
+};
 export function Trans({
   i18nKey,
   count,
@@ -37,10 +40,13 @@ export function Trans({
   tOptions,
   ns,
   ...additionalProps
-}: HooksTransProps): any
+}: HooksTransProps): any;
 
-export function useSSR(initialI18nStore: any, initialLanguage: any): void
-export function useTranslation(ns?: Namespace): [i18next.TranslationFunction, i18next.i18n | {}]
+export function useSSR(initialI18nStore: any, initialLanguage: any): void;
+export function useTranslation(
+  ns?: Namespace,
+  options?: UseTranslationOptions,
+): [i18next.TranslationFunction, i18next.i18n | {}];
 
 export function withSSR(): (
   WrappedComponent: React.ComponentClass<{}, any>,
@@ -51,13 +57,13 @@ export function withSSR(): (
       initialLanguage,
       ...rest
     }: {
-      [x: string]: any
-      initialI18nStore: any
-      initialLanguage: any
+      [x: string]: any;
+      initialI18nStore: any;
+      initialLanguage: any;
     },
-  ): React.ComponentElement<{}, React.Component<{}, any, any>>
-  getInitialProps: (ctx: unknown) => Promise<any>
-}
+  ): React.ComponentElement<{}, React.Component<{}, any, any>>;
+  getInitialProps: (ctx: unknown) => Promise<any>;
+};
 export function withTranslation(
   ns?: Namespace,
-): (WrappedComponent: React.ComponentClass<any>) => (props: any) => any
+): (WrappedComponent: React.ComponentClass<any>) => (props: any) => any;


### PR DESCRIPTION
Add some missing typings from latest hooks variant change and also some improvements

- Make some `Trans` props optional
- Add second argument to `useTranslation`
- Sync with prettier

Might also want to use i18next/i18next#1163 like #665 does for `t` in `useTranslation` return, but I leave it as it is right now