### PR TITLE
bump version i18next in development

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-jsx-a11y": "6.1.1",
     "eslint-plugin-prettier": "2.7.0",
     "eslint-plugin-react": "7.11.1",
-    "i18next": "^13.1.4",
+    "i18next": "^13.1.5",
     "jest": "23.6.0",
     "jest-cli": "23.6.0",
     "mkdirp": "0.5.1",


### PR DESCRIPTION
Trivial, But it may be pereferable for conservation ts test as i18next type parameters changed.
- I confirmed no breaking tests.