### PR TITLE
TFunction usage inside NamespacesConsumer should behave

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "yargs": "12.0.5"
   },
   "peerDependencies": {
-    "i18next": ">= 14.0.0",
+    "i18next": ">= 14.0.1",
     "react": ">= 16.3.0"
   },
   "scripts": {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -75,7 +75,7 @@ export interface NamespacesConsumerProps extends ReactI18NextOptions {
   initialI18nStore?: {};
   initialLanguage?: string;
   children: (
-    t: i18next.WithT['t'],
+    t: i18next.TFunction,
     options: {
       i18n: i18next.i18n;
       lng: string;

--- a/test/typescript/NamespacesConsumer.test.tsx
+++ b/test/typescript/NamespacesConsumer.test.tsx
@@ -18,3 +18,25 @@ function workWithOptionalProps() {
     <NamespacesConsumer i18n={i18next}>{t => <Control hint={t('title')} />}</NamespacesConsumer>
   );
 }
+
+function workWithVariousResults() {
+  return (
+    <NamespacesConsumer i18n={i18next}>
+      {(t, { i18n }) => {
+        // sanity first - tests from i18next t.test
+        const is: string = i18n.t('friend'); // same as <string>
+        const io: object = i18n.t<object>('friend');
+        const isa: string[] = i18n.t<string[]>('friend');
+        const ioa: object[] = i18n.t<object[]>('friend');
+
+        // now try t provided by NamespacesConsumer
+        const s: string = t('friend'); // same as <string>
+        const o: object = t<object>('friend');
+        const sa: string[] = t<string[]>('friend');
+        const oa: object[] = t<object[]>('friend');
+
+        return <div>foo</div>;
+      }}
+    </NamespacesConsumer>
+  );
+}

--- a/test/typescript/NamespacesConsumer.test.tsx
+++ b/test/typescript/NamespacesConsumer.test.tsx
@@ -6,3 +6,15 @@ function withi18nProp() {
   // const i18n = i18next.init({});
   return <NamespacesConsumer i18n={i18next}>{t => <h2>{t('title')}</h2>}</NamespacesConsumer>;
 }
+
+function workWithOptionalProps() {
+  interface ControlProps {
+    hint?: string;
+  }
+  function Control(props: ControlProps) {
+    return <div>{props.hint === undefined ? 'undefined' : props.hint}</div>;
+  }
+  return (
+    <NamespacesConsumer i18n={i18next}>{t => <Control hint={t('title')} />}</NamespacesConsumer>
+  );
+}


### PR DESCRIPTION
Closes #693 - optional props
Closes #695 - parameterized return type usage

Depends on:
https://github.com/i18next/i18next/pull/1188
