### PR TITLE
Add TS definition for reportNS prop

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -89,6 +89,7 @@ export const NamespacesConsumer: React.ComponentClass<NamespacesConsumerProps>;
 export interface I18nextProviderProps {
   i18n: i18next.i18n;
   defaultNS?: string;
+  reportNS?: (ns: string) => void;
   initialI18nStore?: {};
   initialLanguage?: string;
 }


### PR DESCRIPTION
The reportNS prop of I18nextProvider is missing in I18nextProviderProps.

https://github.com/i18next/react-i18next/blob/5e929b56709d92c1bce87cb939bb00800ebfafb0/src/I18nextProvider.js#L14

It was added in PR https://github.com/i18next/react-i18next/pull/500

