### PR TITLE
Add ready/tReady type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "babel-plugin-macros": "^2.5.0",
     "babel-plugin-tester": "^5.5.2",
     "coveralls": "^3.0.2",
-    "dtslint": "^0.5.3",
+    "dtslint": "0.5.3",
     "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "^1.9.1",
     "enzyme-adapter-react-helper": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "babel-plugin-macros": "^2.5.0",
     "babel-plugin-tester": "^5.5.2",
     "coveralls": "^3.0.2",
-    "dtslint": "^0.4.2",
+    "dtslint": "^0.5.3",
     "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "^1.9.1",
     "enzyme-adapter-react-helper": "^1.3.2",
@@ -74,7 +74,7 @@
     "rollup-plugin-replace": "^2.1.0",
     "rollup-plugin-terser": "^4.0.4",
     "sinon": "^7.2.3",
-    "tslint": "^5.12.1",
+    "tslint": "^5.13.1",
     "typescript": "^3.3.3",
     "yargs": "12.0.5"
   },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "rollup-plugin-replace": "^2.1.0",
     "rollup-plugin-terser": "^4.0.4",
     "sinon": "^7.2.3",
-    "tslint": "^5.13.1",
+    "tslint": "5.13.1",
     "typescript": "^3.3.3",
     "yargs": "12.0.5"
   },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "babel-plugin-macros": "^2.5.0",
     "babel-plugin-tester": "^5.5.2",
     "coveralls": "^3.0.2",
-    "dtslint": "0.5.3",
+    "dtslint": "^0.5.3",
     "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "^1.9.1",
     "enzyme-adapter-react-helper": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "rollup-plugin-replace": "^2.1.0",
     "rollup-plugin-terser": "^4.0.4",
     "sinon": "^7.2.3",
-    "tslint": "5.13.1",
+    "tslint": "^5.13.1",
     "typescript": "^3.3.3",
     "yargs": "12.0.5"
   },

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -42,9 +42,10 @@ export function useSSR(initialI18nStore: any, initialLanguage: any): void;
 export interface UseTranslationOptions {
   i18n?: i18next.i18n;
 }
-export type UseTranslationResponse = [i18next.TFunction, i18next.i18n] & {
+export type UseTranslationResponse = [i18next.TFunction, i18next.i18n, boolean] & {
   t: i18next.TFunction;
   i18n: i18next.i18n;
+  ready: boolean;
 };
 export function useTranslation(
   ns?: Namespace,
@@ -69,6 +70,7 @@ export function withSSR(): (
 
 export interface WithTranslation extends i18next.WithT {
   i18n: i18next.i18n;
+  tReady: boolean;
 }
 export function withTranslation(
   ns?: Namespace,

--- a/test/typescript/examples.test.tsx
+++ b/test/typescript/examples.test.tsx
@@ -60,3 +60,27 @@ export default function App() {
     </React.Suspense>
   );
 }
+
+export function componentsWithoutSuspenseUsage() {
+  // Component that uses ready to wait until translations are loaded because useSuspense is set to false
+  function ComponentNotUsingSuspense() {
+    const { t, ready } = useTranslation();
+    return <div>{ready && t('key1')}</div>;
+  }
+
+  // Class based component that uses tReady to wait until translations are loaded because useSuspense is set to false
+  class ClassComponentNotUsingSuspense extends React.Component<WithTranslation> {
+    render() {
+      const { t, tReady } = this.props;
+      return <h2>{tReady && t('title')}</h2>;
+    }
+  }
+  const NotUsingSuspense = withTranslation()(ClassComponentNotUsingSuspense);
+
+  return (
+    <React.Fragment>
+      <ComponentNotUsingSuspense />
+      <NotUsingSuspense />
+    </React.Fragment>
+  );
+}


### PR DESCRIPTION
Adds missing type definitions for the `ready` return value of the `useTranslation` hook and the `tReady` prop added by the `withTranslation` HOC, fixes #751.