### PR TITLE
Allow to enable/disable useSuspense at a hook or component level.

### DIFF
--- a/src/useTranslation.js
+++ b/src/useTranslation.js
@@ -65,7 +65,8 @@ export function useTranslation(ns, props = {}) {
   if (ready) return ret;
 
   // not yet loaded namespaces -> load them -> and return if useSuspense option set false
-  if (!ready && !i18nOptions.useSuspense) {
+  const { useSuspense = i18nOptions.useSuspense } = props;
+  if (!ready && !useSuspense) {
     loadNamespaces(i18n, namespaces, () => {
       resetT();
     });


### PR DESCRIPTION
This new option `useSuspense` on the hook should help migration from 9.x to 10.x and progressive integration of Suspense