### PR TITLE
Resolve #773 by sending console as the first argument to apply

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
 export function warn(...args) {
   if (console && console.warn) {
     if (typeof args[0] === 'string') args[0] = `react-i18next:: ${args[0]}`;
-    console.warn.apply(null, args);
+    console.warn.apply(console, args);
   }
 }
 


### PR DESCRIPTION
Resolves #773 

The bug was due to sending `null` as the context to `console.warn.apply`.

Fixed by passing `console` as the context.