### PR TITLE
Enable replacing keywords with values that are React components

### DIFF
--- a/test/i18n.js
+++ b/test/i18n.js
@@ -15,6 +15,8 @@ i18n.init({
         key1: 'test',
         interpolateKey: 'add {{insert}} {{up, uppercase}}',
         interpolateKey2: '<strong>add</strong> {{insert}} {{up, uppercase}}',
+        interpolateKey3: `Put a line break here:{{br}}And then have more text afterward.`,
+        interpolateKey4: `Put a <0>line break here</0>:{{br}}<1>And then have more text afterward.</1>`,
         transTest1: 'Go <1>there</1>.',
         transTest1_noParent: '<0>Go <1>there</1>.</0>',
         transTest1_customHtml: 'Go <br/><1>there</1>.',

--- a/test/trans.render.spec.js
+++ b/test/trans.render.spec.js
@@ -364,3 +364,58 @@ describe('trans should not break on invalid node from translations - part2', () 
     expect(wrapper.contains(<div>&lt;hello&gt;</div>)).toBe(true);
   });
 });
+
+describe('replace keyword with component', () => {
+  it('should replace keyword with component', () => {
+    const TestElement = () => <Trans i18nKey="interpolateKey3" values={{ br: <br /> }} />;
+    const wrapper = mount(<TestElement />);
+    expect(
+      wrapper.contains(
+        <div>
+          Put a line break here:
+          <br />
+          And then have more text afterward.
+        </div>,
+      ),
+    ).toBe(true);
+  });
+
+  it('should replace keyword when a list of components exists', () => {
+    const TestElement = () => (
+      <Trans
+        i18nKey="interpolateKey4"
+        values={{ br: <br /> }}
+        components={[<em className="test">replace</em>, <span className="test">replace</span>]}
+      />
+    );
+    const wrapper = mount(<TestElement />);
+    expect(
+      wrapper.contains(
+        <div>
+          Put a <em className="test">line break here</em>:
+          <br />
+          <span className="test">And then have more text afterward.</span>
+        </div>,
+      ),
+    ).toBe(true);
+  });
+
+  it('should use the default value with no issues', () => {
+    const TestElement = () => (
+      <Trans i18nKey="interpolateKey5">
+        Put a <em className="test">line break here</em>:<br />
+        <span className="test">And then have more text afterward.</span>
+      </Trans>
+    );
+    const wrapper = mount(<TestElement />);
+    expect(
+      wrapper.contains(
+        <div>
+          Put a <em className="test">line break here</em>:
+          <br />
+          <span className="test">And then have more text afterward.</span>
+        </div>,
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
I wanted to be able to use my existing translations where I have things like `{br}` (I'm porting over ICU translations) to signify inserting line breaks (or other such components).

Since I found that I was only able to do it with the `<0></0>` notation, I thought it wasn't very intuitive nor friendly for non-technical people editing translation files (the advice on getting the correct numbered node [here](https://react.i18next.com/latest/trans-component#how-to-get-the-correct-translation-string) also seemed like a huge future headache to have to do for each translation string that required interpolating a line break/component node).

I think I've managed to solve it in which it supports all existing `react-i18next` features as well.

This was my first foray into the codebase and my brain's not fully wired to the `i18next` architecture, but I hope it's OK. I'm sure there's lots of other use-cases and gotchas that I might not have covered yet.