### PR TITLE
Add in the requirements part of README: react-dom. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ $ npm install react-i18next
 ### Requirements
 
 - react >= **16.8.0**
+- react-dom >= **16.8.0**
 - react-native >= **0.59.0**
 - i18next >= **10.0.0**
 


### PR DESCRIPTION
In the `Requirements` part of the README, `react-dom` was not present. But with version 10 of i18next using React Hooks, you have to have`react-dom >= 16.8.0` otherwise it will throw an error like the following: 
```
Hooks can only be called inside the body of a function component. (https://fb.me/react-invalid-hook-call)
```

Anyway thanks for your great job 👍 