### PR TITLE
Fix the displayName of HOC components

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -69,3 +69,11 @@ export function hasLoadedNamespace(ns, i18n) {
 
   return false;
 }
+
+export function getDisplayName(Component) {
+  return (
+    Component.displayName ||
+    Component.name ||
+    (typeof Component === 'string' && Component.length > 0 ? Component : 'Unknown')
+  );
+}

--- a/src/withSSR.js
+++ b/src/withSSR.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useSSR } from './useSSR';
 import { composeInitialProps } from './context';
+import { getDisplayName } from './utils';
 
 export function withSSR() {
   return function Extend(WrappedComponent) {
@@ -13,6 +14,7 @@ export function withSSR() {
     }
 
     I18nextWithSSR.getInitialProps = composeInitialProps(WrappedComponent);
+    I18nextWithSSR.displayName = `withI18nextSSR(${getDisplayName(WrappedComponent)})`;
 
     return I18nextWithSSR;
   };

--- a/src/withTranslation.js
+++ b/src/withTranslation.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from './useTranslation';
+import { getDisplayName } from './utils';
 
 export function withTranslation(ns) {
   return function Extend(WrappedComponent) {
@@ -13,6 +14,10 @@ export function withTranslation(ns) {
         tReady: ready,
       });
     }
+
+    I18nextWithTranslation.displayName = `withI18nextTranslation(${getDisplayName(
+      WrappedComponent,
+    )})`;
 
     return I18nextWithTranslation;
   };


### PR DESCRIPTION
Updating the HOC components to have displayNames consistent with the react docs definition: https://reactjs.org/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging
This affects some dev tools like react-cosmos that use this format to detect what the "Original" component name is. Also standard is good.