### PR TITLE
export I18nextContext to allow users to get the context instance of i18next

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -87,6 +87,7 @@ export interface I18nextProviderProps {
 }
 
 export const I18nextProvider: React.FunctionComponent<I18nextProviderProps>;
+export const I18nContext: React.Context<i18next.i18n>;
 
 export interface TranslationProps {
   children: (

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ export { withSSR } from './withSSR';
 export { useSSR } from './useSSR';
 
 export {
+  I18nContext,
   initReactI18next,
   setDefaults,
   getDefaults,


### PR DESCRIPTION
Linked to #823, it could be useful for users to have access to the i18next instance in context.