### PR TITLE
Fix useEffect mount/unmount usage

### DIFF
--- a/src/useTranslation.js
+++ b/src/useTranslation.js
@@ -72,7 +72,7 @@ export function useTranslation(ns, props = {}) {
       if (bindI18nStore && i18n)
         bindI18nStore.split(' ').forEach(e => i18n.store.off(e, boundReset));
     };
-  });
+  }, []);
 
   const ret = [t.t, i18n, ready];
   ret.t = t.t;


### PR DESCRIPTION
The second params of useEffect should be `[]`, otherwise it will be called when re-render every time.