### PR TITLE
HOC: expose wrapped component as WrappedComponent property

### DIFF
--- a/src/withSSR.js
+++ b/src/withSSR.js
@@ -15,6 +15,7 @@ export function withSSR() {
 
     I18nextWithSSR.getInitialProps = composeInitialProps(WrappedComponent);
     I18nextWithSSR.displayName = `withI18nextSSR(${getDisplayName(WrappedComponent)})`;
+    I18nextWithSSR.WrappedComponent = WrappedComponent;
 
     return I18nextWithSSR;
   };

--- a/src/withTranslation.js
+++ b/src/withTranslation.js
@@ -22,6 +22,9 @@ export function withTranslation(ns, options = {}) {
     I18nextWithTranslation.displayName = `withI18nextTranslation(${getDisplayName(
       WrappedComponent,
     )})`;
+
+    I18nextWithTranslation.WrappedComponent = WrappedComponent;
+
     return options.withRef ? React.forwardRef(I18nextWithTranslation) : I18nextWithTranslation;
   };
 }

--- a/test/withSSR.spec.js
+++ b/test/withSSR.spec.js
@@ -47,6 +47,11 @@ describe('withSSR', () => {
     setI18n(i18n);
   });
 
+  it('should export wrapped component', () => {
+    const HocElement = withSSR()(TestComponent);
+    expect(HocElement.WrappedComponent).toBe(TestComponent);
+  });
+
   it('should set values', () => {
     const HocElement = withSSR()(TestComponent);
     const wrapper = mount(<HocElement initialI18nStore={{ foo: 'bar' }} initialLanguage="de" />);

--- a/test/withTranslation.spec.js
+++ b/test/withTranslation.spec.js
@@ -13,6 +13,11 @@ describe('withTranslation', () => {
     return <div>{t('key1')}</div>;
   }
 
+  it('should export wrapped component', () => {
+    const HocElement = withTranslation()(TestComponent);
+    expect(HocElement.WrappedComponent).toBe(TestComponent);
+  });
+
   it('should render correct content', () => {
     const HocElement = withTranslation()(TestComponent);
     const wrapper = mount(<HocElement />);


### PR DESCRIPTION
Hi, this PR will add a public static property `WrappedComponent` (tests included) to access original component.

It looks like a *de facto* standard in *higher order components*, at least that's what `react-router` and `react-redux` do, so I expected any higher order component to do the same. This allows to access original component in a standardized way and access its original static properties (in my case, a `loadData` property used for server-side data fetching, but that could be anything else). Without this property, I can't use your HOC with mine as it "breaks the chain". This PR includes implementation and test :+1:

Thanks for your work!

Note: this is quite the same PR which was merged last week in dunglas/react-esi#6