### PR TITLE
Restore support passing the defaultNS as I18nextProvider prop 

### DIFF
--- a/src/I18nextProvider.js
+++ b/src/I18nextProvider.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { I18nContext, usedI18nextProvider } from './context';
 
-export function I18nextProvider({ i18n, children }) {
+export function I18nextProvider({ i18n, defaultNS, children }) {
   usedI18nextProvider(true);
 
   return React.createElement(
@@ -9,6 +9,7 @@ export function I18nextProvider({ i18n, children }) {
     {
       value: {
         i18n,
+        defaultNS,
       },
     },
     children,

--- a/src/useTranslation.js
+++ b/src/useTranslation.js
@@ -11,7 +11,9 @@ import { warnOnce, loadNamespaces, hasLoadedNamespace } from './utils';
 export function useTranslation(ns, props = {}) {
   // assert we have the needed i18nInstance
   const { i18n: i18nFromProps } = props;
-  const { i18n: i18nFromContext } = getHasUsedI18nextProvider() ? useContext(I18nContext) : {};
+  const { i18n: i18nFromContext, defaultNS: defaultNSFromContext } = getHasUsedI18nextProvider()
+    ? useContext(I18nContext)
+    : {};
   const i18n = i18nFromProps || i18nFromContext || getI18n();
   if (i18n && !i18n.reportNamespaces) i18n.reportNamespaces = new ReportNamespaces();
   if (!i18n) {
@@ -26,7 +28,7 @@ export function useTranslation(ns, props = {}) {
   const { useSuspense = i18nOptions.useSuspense } = props;
 
   // prepare having a namespace
-  let namespaces = ns || (i18n.options && i18n.options.defaultNS);
+  let namespaces = ns || defaultNSFromContext || (i18n.options && i18n.options.defaultNS);
   namespaces = typeof namespaces === 'string' ? [namespaces] : namespaces || ['translation'];
 
   // report namespaces as used

--- a/test/useTranslation.spec.js
+++ b/test/useTranslation.spec.js
@@ -2,9 +2,11 @@ import React from 'react';
 import { mount } from 'enzyme';
 import i18nInstance from './i18n';
 import { useTranslation } from '../src/useTranslation';
-import { setI18n } from '../src/context';
+import { setI18n, usedI18nextProvider } from '../src/context';
+import { I18nextProvider } from '../src/I18nextProvider';
 
 jest.unmock('../src/useTranslation');
+jest.unmock('../src/I18nextProvider');
 
 describe('useTranslation', () => {
   describe('object', () => {
@@ -100,6 +102,37 @@ describe('useTranslation', () => {
       const wrapper = mount(<TestComponent />, {});
       // console.log(wrapper.debug());
       expect(wrapper.contains(<div>key1</div>)).toBe(true);
+    });
+  });
+
+  describe('default namespace from context', () => {
+    function TestComponent() {
+      const { t } = useTranslation();
+
+      expect(typeof t).toBe('function');
+
+      return <div>{t('key1')}</div>;
+    }
+
+    beforeEach(() => {
+      usedI18nextProvider(false);
+    });
+
+    afterEach(() => {
+      i18nInstance.reportNamespaces.usedNamespaces = {};
+    });
+
+    it('should render content fallback', () => {
+      const namespace = 'sampleNS';
+      const wrapper = mount(
+        <I18nextProvider defaultNS={namespace} i18={i18nInstance}>
+          <TestComponent />
+        </I18nextProvider>,
+        {},
+      );
+
+      expect(wrapper.contains(<div>key1</div>)).toBe(true);
+      expect(i18nInstance.reportNamespaces.getUsedNamespaces()).toContain(namespace);
     });
   });
 });


### PR DESCRIPTION
During react-i18next evolved the support (introduced at i18next/react-i18next#478) of `defaultNS` prop has been dropped from I18nextProvider. So attempting to restore it.
We're still looking forward to share same instance of i18next between different provider instances and hooks.
```javascript
const i18n = /* some i18next instantiating */
const Translated = () => {
  const {t} = useTranslation();

  return (<div>{t('the_key')}</div>);
};
const FirstWrapper = () => (
  <I18nextProvider i18n={i18n} defaultNS="firstOne">
    <Translated />
  </I18nextProvider>
);
const SecondWrapper = () => (
  <I18nextProvider i18n={i18n} defaultNS="secondOne">
    <Translated />
  </I18nextProvider>
);
```