### PR TITLE
Update I18nextProvider.js

### DIFF
--- a/src/I18nextProvider.js
+++ b/src/I18nextProvider.js
@@ -1,6 +1,12 @@
 import React from 'react';
 import { I18nContext, usedI18nextProvider } from './context';
 
+const _warnRemovedContextProp = prop => {
+  console.warn(
+    `[react-i18next] I18nextProvider no longer provides "${prop}" as a context prop, please upgrade your code: https://react.i18next.com/latest/migrating-v9-to-v10`
+  );
+};
+
 export function I18nextProvider({ i18n, defaultNS, children }) {
   usedI18nextProvider(true);
 
@@ -10,6 +16,9 @@ export function I18nextProvider({ i18n, defaultNS, children }) {
       value: {
         i18n,
         defaultNS,
+        reportNS: _warnRemovedContextProp('reportNS'),
+        lng: _warnRemovedContextProp('lng'),
+        t: _warnRemovedContextProp('t')
       },
     },
     children,


### PR DESCRIPTION
Because of missing migration documentation (docs added in: https://github.com/i18next/react-i18next-gitbook/pull/53) in `next-i18next` which uses `react-i18next` a bug was introduced which prevented the normal working of the `Link` component. Cfr: https://github.com/isaachinman/next-i18next/issues/348

This PR adds a warning when a user tries to use a removed context prop.