### PR TITLE
Reload translations whenever namespaces passed to useTranslation() change

### DIFF
--- a/src/useTranslation.js
+++ b/src/useTranslation.js
@@ -74,7 +74,7 @@ export function useTranslation(ns, props = {}) {
       if (bindI18nStore && i18n)
         bindI18nStore.split(' ').forEach(e => i18n.store.off(e, boundReset));
     };
-  }, []); // define props to trigger using effect on rerender (none here)
+  }, [namespaces.join()]); // re-run effect whenever list of namespaces changes
 
   const ret = [t.t, i18n, ready];
   ret.t = t.t;


### PR DESCRIPTION
When dynamically changing the `namespaces` passed to `useTranslation()` over time, they are now reloaded and trigger a re-render. This reimplements the behavior first introduced in #523 as it was likely broken in the release of the new hooks-based API.

See https://github.com/i18next/react-i18next/issues/817#issuecomment-503650139 and #520 for context.