### PR TITLE
Add translation alias

### DIFF
--- a/src/withTranslation.js
+++ b/src/withTranslation.js
@@ -6,10 +6,10 @@ export function withTranslation(ns, options = {}) {
   return function Extend(WrappedComponent) {
     function I18nextWithTranslation(props, ref) {
       const [t, i18n, ready] = useTranslation(ns, props);
-
       const passDownProps = {
         ...props,
         t,
+        translate: t,
         i18n,
         tReady: ready,
       };


### PR DESCRIPTION
I've noticed a lot of development teams like to rename the `t` to` translate`. 