### PR TITLE
withTranslation creates a property T as a shortcut for Trans

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -69,6 +69,7 @@ export function withSSR(): (
 export interface WithTranslation extends i18next.WithT {
   i18n: i18next.i18n;
   tReady: boolean;
+  T: FunctionComponent<TransProps>;
 }
 export function withTranslation(
   ns?: Namespace,

--- a/src/withTranslation.js
+++ b/src/withTranslation.js
@@ -1,17 +1,26 @@
 import React from 'react';
 import { useTranslation } from './useTranslation';
 import { getDisplayName } from './utils';
+import { Trans } from './Trans';
 
 export function withTranslation(ns, options = {}) {
   return function Extend(WrappedComponent) {
     function I18nextWithTranslation(props, ref) {
       const [t, i18n, ready] = useTranslation(ns, props);
 
+      function T(transProps) {
+        return React.createElement(Trans, {
+          ...transProps,
+          t: transProps.t || t,
+        });
+      }
+
       const passDownProps = {
         ...props,
         t,
         i18n,
         tReady: ready,
+        T,
       };
       if (options.withRef && ref) {
         passDownProps.ref = ref;

--- a/test/withTranslation.spec.js
+++ b/test/withTranslation.spec.js
@@ -6,8 +6,9 @@ import { withTranslation } from '../src/withTranslation';
 jest.unmock('../src/withTranslation');
 
 describe('withTranslation', () => {
-  function TestComponent({ t, i18n: instance }) {
+  function TestComponent({ t, i18n: instance, T }) {
     expect(typeof t).toBe('function');
+    expect(typeof T).toBe('function');
     expect(instance).toBe(i18n);
 
     return <div>{t('key1')}</div>;


### PR DESCRIPTION
First, my apologies if I'm doing something wrong. This is my first pull request in GitHub. I just had an easy-to-achieve idea that seems to make sense, so I felt like contributing.

I had a little trouble using the `Trans` component inside a component wrapped with `withTranslation`. Then I found out I had to provide the `t={t}` property.

It sounds rather unintuitive and not very convenient to me.

**So here's my proposal**: let's have `withTranslation` pass a new property `T` which would be a   shortcut for the `Trans` component with a default `t` property.

The following:

```javascript
import { Trans, withTranslation } from 'react-i18next';

const MyComponent = ({ t }) => (
  <div>
    <h1>{t('myTitle')}</h1>
    <Trans t={t} i18nKey="mySentenceWithMarkup">
      Click <Link="/">here</Link> to get back to homepage.
    </Trans>
  </div>
);
export default withTranslation('myNamespace')(MyComponent);
```

Could be written like this:

```javascript
import { withTranslation } from 'react-i18next';

const MyComponent = ({ t, T }) => (
  <div>
    <h1>{t('myTitle')}</h1>
    <T i18nKey="mySentenceWithMarkup">
      Click <Link="/">here</Link> to get back to homepage.
    </T>
  </div>
);
export default withTranslation('myNamespace')(MyComponent);
```

Sure, it is not much, but it seems like a step in the right direction, having a code a bit more simple. Plus, I find it to be more consistent: the wrapper provides for both ready-to-use function and component, instead of having to provide the right property for a component coming for an import.

As you can see, it is pretty simple to achieve. However, I'm a little concerned about `useTranslation`. Why would it not make the `T` function? Then shortcut would be available through that function (someone might find it convenient), and `withTranslation` would just pass it.

But I felt like it is a more sensitive change and I was worried it could had side-effect, especially if some users are reading its return as an array. Just adding the `T` property sounds pretty harmless as far as I know, but I was not be sure what to do with the array itself. So I decided to just modify `withTranslation` and leave `useTranslation` until it's been discussed.

My second concern is about the `displayName` and `WrappedComponent` properties. Should the `T` function have them? It does not seem necessary to me, but maybe there's something I'm not thinking about.

Or maybe there is a way to modify the Trans component directly in order to avoid adding a level of component? I could not think of a reliable way so far. Going though parent components trying to find a `t` property sounds like a bad idea, doesn't it?

Of course I've used the `npm run test`, especially since I went to the trouble of updating `test\withTranslation.spec.js`. It passed, but it's not testing much though. Like it does not verify the behavior of `T`.

Looking forward for your feedback,
Adrien