### PR TITLE
Improve withSSR type definition

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -51,18 +51,17 @@ export function useTranslation(
 ): UseTranslationResponse;
 
 // Need to see usage to improve this
-export function withSSR(): (
-  WrappedComponent: React.ComponentClass<{}, any>,
+export function withSSR(): <Props>(
+  WrappedComponent: React.ComponentType<Props>,
 ) => {
   ({
     initialI18nStore,
     initialLanguage,
     ...rest
   }: {
-    [x: string]: any;
-    initialI18nStore: any;
-    initialLanguage: any;
-  }): React.ComponentElement<{}, React.Component<{}, any, any>>;
+    initialI18nStore: i18next.Resource;
+    initialLanguage: string;
+  } & Props): React.FunctionComponentElement<Props>;
   getInitialProps: (ctx: unknown) => Promise<any>;
 };
 

--- a/test/typescript/withSSR.test.tsx
+++ b/test/typescript/withSSR.test.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { withSSR } from 'react-i18next';
+
+class ClassComponent extends React.Component {
+  render() {
+    return null;
+  }
+}
+
+const ExtendedClass = withSSR()(ClassComponent);
+
+<ExtendedClass initialLanguage={'en'} initialI18nStore={{ en: { namespace: { key: 'value' } } }} />;
+
+class ClassComponentWithProps extends React.Component<{ foo: number }> {
+  render() {
+    return null;
+  }
+}
+
+const ExtendedClassWithProps = withSSR()(ClassComponentWithProps);
+
+<ExtendedClassWithProps
+  initialLanguage={'en'}
+  initialI18nStore={{ en: { namespace: { key: 'value' } } }}
+  foo={1}
+/>;
+
+const FunctionComponent = () => {
+  return null;
+};
+
+const ExtendedFn = withSSR()(FunctionComponent);
+
+<ExtendedFn initialLanguage={'en'} initialI18nStore={{ en: { namespace: { key: 'value' } } }} />;
+
+const FunctionComponentWithProps: React.FunctionComponent<{ foo: string }> = props => {
+  return null;
+};
+
+const ExtendedFnWithProp = withSSR()(FunctionComponentWithProps);
+
+<ExtendedFnWithProp
+  initialLanguage={'en'}
+  initialI18nStore={{ en: { namespace: { key: 'value' } } }}
+  foo="bar"
+/>;


### PR DESCRIPTION
Currently, there are few issues with the `withSSR` type definitions:

1. Function components aren't valid
1. Any component (class or function) with props were invalid
1. No type-safety around `initialI18nStore` and `initialLanguage`

### Function Components

```typescript
const FunctionComponent = () => {
  return null;
};

const ExtendedFn = withSSR()(FunctionComponent);
//                           ^^^^^^^^^^^^^^^^^
// Type '() => null' provides no match for the signature 'new (props: {}, context?: any): Component<{}, any, any>'

<ExtendedFn initialLanguage={'en'} initialI18nStore={{ en: { namespace: { key: 'value' } } }} />;
```

This is because the type definition for `WrappedComponent` is `React.ComponentClass` which doesn't include `React.FunctionComponent`. This can be solved with the `React.ComponentType`.

### Class Components

```typescript
class ClassComponentWithProps extends React.Component<{ foo: number }> {
  render() {
    return null;
  }
}

const ExtendedClassWithProps = withSSR()(ClassComponentWithProps);
//                                       ^^^^^^^^^^^^^^^^^^^^^^^
// Property 'foo' is missing in type '{}' but required in type 'Readonly<{ foo: number; }>'

<ExtendedClassWithProps
  initialLanguage={'en'}
  initialI18nStore={{ en: { namespace: { key: 'value' } } }}
  foo={1}
/>;
```

This is because the type definition for `WrappedComponent` is `React.ComponentClass<{}, any>` meaning only props of type `{}` are valid (a.k.a no props). This can be fixed with a generic `Props`.

#### `initialI18nStore` and `initialLanguage`

```typescript
class ClassComponent extends React.Component {
  render() {
    return null;
  }
}

const ExtendedClass = withSSR()(ClassComponent);

<ExtendedClass initialLanguage={1234} initialI18nStore={5678} />;
//                              ^^^^                    ^^^^
//                             valid                   valid
```

From what I can infer from the docs and source, `initialLanguage` should be of type `string`. I am less confident about `initialI18nStore` but it _appears_ it should be of type `Resource`? I'm basing this assumption off these types:

https://github.com/i18next/i18next/blob/85bbb39d66dc30ade0693c20076cbb4f84fd7652/index.d.ts#L650-L662

But in the code in this repo, it appears it's used as `i18n.services.resourceStore.data = initialI18nStore;` (and not `i18n.services.resourceStore= initialI18nStore;`) which these types suggest?

https://github.com/i18next/i18next/blob/85bbb39d66dc30ade0693c20076cbb4f84fd7652/index.d.ts#L672-L681