### PR TITLE
Update types for reportNamespaces

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,8 +7,6 @@ export type Namespace = string | string[];
 
 export function setDefaults(options: i18next.ReactOptions): void;
 export function getDefaults(): i18next.ReactOptions;
-export function addUsedNamespaces(namespaces: Namespace[]): void;
-export function getUsedNamespaces(): string[];
 export function setI18n(instance: i18next.i18n): void;
 export function getI18n(): i18next.i18n;
 export const initReactI18next: i18next.ThirdPartyModule;
@@ -19,6 +17,17 @@ export function getInitialProps(): {
   };
   initialLanguage: string;
 };
+
+export interface ReportNamespaces {
+  addUsedNamespaces(namespaces: Namespace[]): void;
+  getUsedNamespaces(): string[];
+}
+
+declare module 'i18next' {
+  interface i18n {
+    reportNamespaces: ReportNamespaces;
+  }
+}
 
 export interface TransProps extends Partial<i18next.WithT> {
   children?: React.ReactNode;

--- a/test/typescript/context.test.tsx
+++ b/test/typescript/context.test.tsx
@@ -1,0 +1,4 @@
+import * as i18next from 'i18next';
+
+i18next.reportNamespaces.addUsedNamespaces(['translation']);
+i18next.reportNamespaces.getUsedNamespaces();


### PR DESCRIPTION
I'm working with SSR and stumbled across this issue and need access to only the used namespaces: https://github.com/i18next/react-i18next/issues/711.

As it appears, the suggestion is to use `i18next.reportNamespaces.getUsedNamespaces()`?

However, the types do not currently reflect that. 

### Previously

```typescript
import * as i18next from 'i18next';

i18next.reportNamespaces.addUsedNamespaces(['translation']);
//      ^^^^^^^^^^^^^^^^
// Property 'reportNamespaces' does not exist on type 'i18n'
i18next.reportNamespaces.getUsedNamespaces();
//      ^^^^^^^^^^^^^^^^
// Property 'reportNamespaces' does not exist on type 'i18n'
```

### After this Change

```typescript
import * as i18next from 'i18next';

i18next.reportNamespaces.addUsedNamespaces(['translation']); // valid
i18next.reportNamespaces.getUsedNamespaces(); // valid, returns: `string[]`
```