### PR TITLE
Use count from `values` object passed to Trans

### DIFF
--- a/src/Trans.js
+++ b/src/Trans.js
@@ -234,10 +234,10 @@ export function Trans({
   const interpolationOverride = values ? {} : { interpolation: { prefix: '#$?', suffix: '?$#' } };
   const combinedTOpts = {
     ...tOptions,
+    count,
     ...values,
     ...interpolationOverride,
     defaultValue,
-    count,
     ns: namespaces,
   };
   const translation = key ? t(key, combinedTOpts) : defaultValue;


### PR DESCRIPTION
If a `count` is specified in the `values` object passed to Trans, we should use it, even if the `count` property is not provided.
https://github.com/i18next/i18next/issues/1330

By changing the order of the construction of `combinedTOpts`, this should ensure that the behaviour is as expected.