### PR TITLE
Update withTranslation HOC to pass statics over

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",
+    "hoist-non-react-statics": "^3.3.0",
     "html-parse-stringify2": "2.0.1"
   },
   "devDependencies": {

--- a/src/withTranslation.js
+++ b/src/withTranslation.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import hoistNonReactStatics from 'hoist-non-react-statics';
 import { useTranslation } from './useTranslation';
 import { getDisplayName } from './utils';
 
@@ -25,6 +26,9 @@ export function withTranslation(ns, options = {}) {
 
     I18nextWithTranslation.WrappedComponent = WrappedComponent;
 
-    return options.withRef ? React.forwardRef(I18nextWithTranslation) : I18nextWithTranslation;
+    return hoistNonReactStatics(
+      options.withRef ? React.forwardRef(I18nextWithTranslation) : I18nextWithTranslation,
+      WrappedComponent,
+    );
   };
 }

--- a/test/withTranslation.spec.js
+++ b/test/withTranslation.spec.js
@@ -12,6 +12,8 @@ describe('withTranslation', () => {
 
     return <div>{t('key1')}</div>;
   }
+  TestComponent.aStaticAttribute = 'aStaticAttribute';
+  TestComponent.aStaticMethod = () => 'aStaticMethod';
 
   it('should export wrapped component', () => {
     const HocElement = withTranslation()(TestComponent);
@@ -23,6 +25,14 @@ describe('withTranslation', () => {
     const wrapper = mount(<HocElement />);
     // console.log(wrapper.debug());
     expect(wrapper.contains(<div>test</div>)).toBe(true);
+  });
+
+  it('should pass over static attributes and methods', () => {
+    const HocElement = withTranslation()(TestComponent);
+    expect(HocElement).toHaveProperty('aStaticAttribute', 'aStaticAttribute');
+    expect(HocElement).toHaveProperty('aStaticMethod');
+    ``;
+    expect(HocElement.aStaticMethod()).toBe('aStaticMethod');
   });
 
   it('should has ref', () => {


### PR DESCRIPTION
This Pull Request is fixing the issue #958.

React Documentation: https://reactjs.org/docs/higher-order-components.html#static-methods-must-be-copied-over