### PR TITLE
Fix import of i18next so that types are extended

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-import * as i18next from 'i18next';
+import i18next from 'i18next';
 import * as React from 'react';
 
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;


### PR DESCRIPTION
When trying to use the `18next` instance provided by `useTranslation` hook in a typescript app there missing definitions. The problem was the import of `i18next` in the typescript definition. Because `esModuleInterop` is enabled then we should use the default export. If you look at i18next's own typescript definition then we can see it is a CommonJS "interop default" export with no named exports:
https://github.com/i18next/i18next/blob/master/index.d.ts#L1008

Allows the following code to pass type check:

```
  const [t, i18n] = useTranslation('common')

  useEffect(() => {
   // otherwise fails with:
   //     Property 'on' does not exist on type 'i18n'.  TS2339
   i18n.on('languageChanged', doThing)
  }, [])
```