### PR TITLE
wip: Indexed Components Prop

### DIFF
--- a/src/Trans.js
+++ b/src/Trans.js
@@ -88,13 +88,7 @@ export function nodesToString(startingString, children, index, i18nOptions) {
   return stringNode;
 }
 
-function renderNodes({
-  children,
-  targetString,
-  i18n,
-  i18nOptions,
-  combinedTOpts
-}) {
+function renderNodes({ children, components, targetString, i18n, i18nOptions, combinedTOpts }) {
   if (targetString === '') return [];
 
   // check if contains tags we need to replace from html string to react nodes
@@ -143,6 +137,11 @@ function renderNodes({
 
         if (typeof child === 'string') {
           mem.push(child);
+        } else if (components) {
+          const mappedChildren = mapAST(components, node.children);
+          const inner = mappedChildren.length === 0 ? null : mappedChildren;
+          if (child.dummy) child.children = inner;
+          mem.push(React.cloneElement(child, { ...child.props, key: i }, inner));
         } else if (hasChildren(child)) {
           const childs = getChildren(child);
           const mappedChildren = mapAST(childs, node.children);
@@ -265,11 +264,7 @@ export function Trans({
     combinedTOpts,
   });
 
-  if (!useAsParent) return renderResult
+  if (!useAsParent) return renderResult;
 
-  return React.createElement(
-    useAsParent,
-    additionalProps,
-    renderResult,
-  );
+  return React.createElement(useAsParent, additionalProps, renderResult);
 }

--- a/src/Trans.js
+++ b/src/Trans.js
@@ -88,7 +88,13 @@ export function nodesToString(startingString, children, index, i18nOptions) {
   return stringNode;
 }
 
-function renderNodes(children, targetString, i18n, i18nOptions, combinedTOpts) {
+function renderNodes({
+  children,
+  targetString,
+  i18n,
+  i18nOptions,
+  combinedTOpts
+}) {
   if (targetString === '') return [];
 
   // check if contains tags we need to replace from html string to react nodes
@@ -250,18 +256,20 @@ export function Trans({
   };
   const translation = key ? t(key, combinedTOpts) : defaultValue;
 
-  if (!useAsParent)
-    return renderNodes(
-      components || children,
-      translation,
-      i18n,
-      reactI18nextOptions,
-      combinedTOpts,
-    );
+  const renderResult = renderNodes({
+    children: components || children,
+    components,
+    targetString: translation,
+    i18n,
+    i18nOptions: reactI18nextOptions,
+    combinedTOpts,
+  });
+
+  if (!useAsParent) return renderResult
 
   return React.createElement(
     useAsParent,
     additionalProps,
-    renderNodes(components || children, translation, i18n, reactI18nextOptions, combinedTOpts),
+    renderResult,
   );
 }

--- a/test/trans.render.spec.js
+++ b/test/trans.render.spec.js
@@ -372,7 +372,8 @@ describe('trans using no children but props - icu case', () => {
   });
 });
 
-describe('trans using no children but props - nested case', () => {
+// TODO: enable old nested behaviour with flag
+describe.skip('trans using no children but props - nested case', () => {
   const TestElement = () => (
     <Trans
       defaults="<0>hello <1></1> {{what}}</0>"
@@ -385,6 +386,7 @@ describe('trans using no children but props - nested case', () => {
       ]}
     />
   );
+
   it('should render translated string', () => {
     const wrapper = mount(<TestElement />);
     // console.log(wrapper.debug());
@@ -393,6 +395,53 @@ describe('trans using no children but props - nested case', () => {
         <span>
           hello <br /> world
         </span>,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('trans using no children but props - nested case', () => {
+  const TestElement = () => (
+    <Trans
+      defaults="<0>hello <1></1> {{what}}</0>"
+      values={{ what: 'world' }}
+      components={[<span key="0" />, <br key="1" />]}
+    />
+  );
+
+  it('should render translated string', () => {
+    const wrapper = mount(<TestElement />);
+    // console.log(wrapper.debug());
+    expect(
+      wrapper.contains(
+        <span>
+          hello <br /> world
+        </span>,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('trans using no children but props - deeply nested case', () => {
+  const TestElement = () => (
+    <Trans
+      defaults="<0>paragraph with <1>italic</1> and <2><1>bold italic</1></2> text</0>"
+      values={{ what: 'world' }}
+      components={[<p key="0" />, <em key="1" />, <strong key="2" />]}
+    />
+  );
+
+  it('should render translated string', () => {
+    const wrapper = mount(<TestElement />);
+    expect(
+      wrapper.contains(
+        <p>
+          paragraph with <em>italic</em> and{' '}
+          <strong>
+            <em>bold italic</em>
+          </strong>{' '}
+          text
+        </p>,
       ),
     ).toBe(true);
   });
@@ -435,7 +484,8 @@ describe('trans should not break on invalid node from translations - part2', () 
 });
 
 describe('Trans should render nested components', () => {
-  it('should render dynamic ul as components property', () => {
+  // TODO: enable old nested behaviour with flag
+  it.skip('should render dynamic ul as components property', () => {
     const list = ['li1', 'li2'];
 
     const TestElement = () => (


### PR DESCRIPTION
This PR alters the current behavior of `<Trans>` `components` prop, as to simplify the API in the case of nested components.

Currently, the `components` array must mimic the nesting used by the translation, and the numbered tags inside the translation "reset" at every new nesting level:

```jsx
<Trans
  defaults="<0>hello <0>there</0></0>" {/* Notice the two <0> tags */}
  components={[
    <span>
      placeholder<em>text</em> {/* <em> is inside <span> */}
    </span>
  ]}
/>

// output: <span>hello <em>there</em></span>
```

The proposed API makes it so the numbered tags inside the translation match the array index passed of `components`:

```jsx
<Trans
  defaults="<0>hello <1>there</1></0>"
  components={[
    <span key='0' />,
    <em key='1' />,
    {/* The `key` props are just there to avoid a warning from React for not
    using keys on an array of elements. But they can also be used to make
    easier to associate a component to where it will be used on the translation. */}
  ]}
/>

// output: <span>hello <em>there</em></span>
```

This should avoid confusion when using nested `components`  array, as it already happened before:

https://github.com/i18next/react-i18next/issues/470
https://github.com/i18next/react-i18next/issues/953
https://github.com/i18next/react-i18next/issues/974

**This PR introduces a breaking change.** Code written in the previous syntax will not work properly anymore. Using `list.map` inside the `components` prop array is no longer supported.
