### PR TITLE
Update `rollup.config.js` for IE11 Transpilations

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,6 +15,7 @@ const babelOptions = {
       {
         targets: {
           esmodules: true,
+          ie: "11"
         },
       },
     ],


### PR DESCRIPTION
Rollup doesn't set targets for browsers.

This commit addresses: https://github.com/i18next/react-i18next/issues/915

My question: is this an appropriate solution? My knowledge of the various JS module types isn't up to the point where I can say definitively one way or the other.