### PR TITLE
Fix withTranslation eating up forwardedRef prop

### DIFF
--- a/src/withTranslation.js
+++ b/src/withTranslation.js
@@ -9,6 +9,7 @@ export function withTranslation(ns, options = {}) {
 
       const passDownProps = {
         ...rest,
+        forwardedRef,
         t,
         i18n,
         tReady: ready,


### PR DESCRIPTION
When wrapping components with only the withTranslation HOC, this code works well:

```js
export const Input =  withTranslation('translation', { withRef: true })(Input),
```

But when using multiple ones, `withTranslation` was not propagating `forwardedRef` to its children, making code like this break (it also used to work in previous versions):

```js
const InputWithRef = compose(
    withTranslation(),
    withSomeOtherHOC(),
    withProps(({ forwardedRef }) => ({ ref: forwardedRef }))
)(Input);

export const Input = React.forwardRef(
    (props, ref) => <InputWithRef {...props} forwardedRef={ref} />
);
```

Fixes #990