### PR TITLE
Only pass forwardedRef to children if options.withRef is false

### DIFF
--- a/src/withTranslation.js
+++ b/src/withTranslation.js
@@ -9,13 +9,14 @@ export function withTranslation(ns, options = {}) {
 
       const passDownProps = {
         ...rest,
-        forwardedRef,
         t,
         i18n,
         tReady: ready,
       };
       if (options.withRef && forwardedRef) {
         passDownProps.ref = forwardedRef;
+      } else if (!options.withRef && forwardedRef) {
+        passDownProps.forwardedRef = forwardedRef;
       }
       return React.createElement(WrappedComponent, passDownProps);
     }
@@ -26,7 +27,8 @@ export function withTranslation(ns, options = {}) {
 
     I18nextWithTranslation.WrappedComponent = WrappedComponent;
 
-    const forwardRef = (props, ref) => React.createElement(I18nextWithTranslation, Object.assign({}, props, { forwardedRef: ref }));
+    const forwardRef = (props, ref) =>
+      React.createElement(I18nextWithTranslation, Object.assign({}, props, { forwardedRef: ref }));
 
     return options.withRef ? React.forwardRef(forwardRef) : I18nextWithTranslation;
   };


### PR DESCRIPTION
`forwardedRef` was always passed down to its children in #992, but as pointed in the comments, it should only be passed down if `options.withRef` is false (if it is true, we want to pass the ref as `ref` and remove `forwardedRef` from props) and if `forwardedRef` is defined.