### PR TITLE
Store should be initialized after useSSR

### DIFF
--- a/src/useSSR.js
+++ b/src/useSSR.js
@@ -15,6 +15,7 @@ export function useSSR(initialI18nStore, initialLanguage, props = {}) {
   if (initialI18nStore && !i18n.initializedStoreOnce) {
     i18n.services.resourceStore.data = initialI18nStore;
     i18n.initializedStoreOnce = true;
+    i18n.isInitialized = true;
   }
 
   if (initialLanguage && !i18n.initializedLanguageOnce) {


### PR DESCRIPTION
If a the store is initialized with data from Server side rendering, it fire these warnings anyway:
`i18next was not initialized... This means something IS WRONG in your application setup.`
However, the application setup is fine, the warning is inconsistent.
I think this PR will do the trick: i18n should be considered as initialize once it receive initialI18nStore datas.