### PR TITLE
fixed graceful fallback for keys

### DIFF
--- a/src/useTranslation.js
+++ b/src/useTranslation.js
@@ -19,8 +19,9 @@ export function useTranslation(ns, props = {}) {
   if (i18n && !i18n.reportNamespaces) i18n.reportNamespaces = new ReportNamespaces();
   if (!i18n) {
     warnOnce('You will need pass in an i18next instance by using initReactI18next');
-    const retNotReady = [k => k, {}, false];
-    retNotReady.t = k => k;
+    const notReadyT = k => (Array.isArray(k) ? k[k.length - 1] : k);
+    const retNotReady = [notReadyT, {}, false];
+    retNotReady.t = notReadyT;
     retNotReady.i18n = {};
     retNotReady.ready = false;
     return retNotReady;

--- a/test/useTranslation.spec.js
+++ b/test/useTranslation.spec.js
@@ -59,7 +59,12 @@ describe('useTranslation', () => {
         expect(typeof t).toBe('function');
         expect(i18n).toEqual({});
 
-        return <div>{t('key1')}</div>;
+        return (
+          <>
+            <div>{t('key1')}</div>
+            <div>{t(['doh', 'Human friendly fallback'])}</div>
+          </>
+        );
       }
 
       it('should render content fallback', () => {
@@ -67,6 +72,7 @@ describe('useTranslation', () => {
         const wrapper = mount(<TestComponent />, {});
         // console.log(wrapper.debug());
         expect(wrapper.contains(<div>key1</div>)).toBe(true);
+        expect(wrapper.contains(<div>Human friendly fallback</div>)).toBe(true);
         expect(console.warn).toHaveBeenCalled();
       });
     });


### PR DESCRIPTION
t accepts an array of keys and will use first resolved key or fallback to the last key https://www.i18next.com/overview/api#t
But when i18next instance is not ready useTranslation hook simply returns an identity function, t(['doh', 'Human friendly fallback']) gives me ['doh', 'Human friendly fallback'] instead of 'Human friendly fallback'