### PR TITLE
Allow ComponentType for Trans' `parent` type.

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -39,7 +39,7 @@ export interface TransProps<E extends Element = HTMLDivElement>
   i18n?: i18n;
   i18nKey?: string;
   ns?: Namespace;
-  parent?: string; // used in React.createElement
+  parent?: string | React.ComponentType<any> | null; // used in React.createElement if not null
   tOptions?: {};
   values?: {};
   t?: TFunction;

--- a/test/typescript/Trans.test.tsx
+++ b/test/typescript/Trans.test.tsx
@@ -55,6 +55,12 @@ function t() {
   return <Trans t={t}>Foo</Trans>;
 }
 
+function CustomRedComponent(props: {children: React.ReactNode}) {
+  return <div style={{color: 'red'}}>
+    {props.children}
+  </div>;
+}
+
 function extraDivProps() {
   return (
     <>
@@ -63,6 +69,8 @@ function extraDivProps() {
       </Trans>
       {/* div is the default parent */}
       <Trans style={{ color: 'green' }}>Foo</Trans>
+      <Trans parent={null}>No parent (overrides the default one)</Trans>
+      <Trans parent={CustomRedComponent}>Use a custom component as parent</Trans>
     </>
   );
 }


### PR DESCRIPTION
I've also allowed `null` as this is the cleanest way I use to override the default parent:
* `undefined` -> use default parent from settings
* `string | React.ComponentType<any>` -> use in `React.createElement`
* `null` -> do not add a parent