### PR TITLE
:memo: Update warning about react-native

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ v10.0.0
 npm i react-i18next
 ```
 
-**react-native: not yet supports hooks (hooks are part of react-native v0.59.0)!!!**
+**react-native: To use hooks within react-native, you must use react-native v0.59.0 or higher**
 
 For the legacy version please use the [v9.x.x Branch](https://github.com/i18next/react-i18next/tree/v9.x.x)
 


### PR DESCRIPTION
I think the actual warning doesn't make sense anymore since the current versions of react-native support hooks ;) ! However, the warning is still usefull to keep in mind that you need 0.59 or higher :)