### PR TITLE
Translation component's ready parameter is missing in TypeScript definition

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -110,6 +110,7 @@ export interface TranslationProps {
       i18n: i18n;
       lng: string;
     },
+    ready: boolean,
   ) => React.ReactNode;
   ns?: Namespace;
   i18n?: i18n;

--- a/test/typescript/Translation.test.tsx
+++ b/test/typescript/Translation.test.tsx
@@ -5,6 +5,14 @@ function basic() {
   return <Translation>{(t, { i18n, lng }) => <div>{t('key1')}</div>}</Translation>;
 }
 
+function ready() {
+  return (
+    <Translation>
+      {(t, { i18n, lng }, ready) => <div>{ready ? t('key1') : 'default'}</div>}
+    </Translation>
+  );
+}
+
 function ns() {
   return <Translation ns="foo">{(t, { i18n, lng }) => <div>{t('key1')}</div>}</Translation>;
 }

--- a/test/typescript/useTranslation.test.tsx
+++ b/test/typescript/useTranslation.test.tsx
@@ -2,11 +2,12 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 
 function defaultObjectUsage() {
-  const { t, i18n } = useTranslation();
+  const { t, i18n, ready } = useTranslation();
 
   // ensure the i18n here is still exposing original type
   const language = i18n.language;
   i18n.languages.join(', ');
+  const r: boolean = ready;
 
   return (
     <div>
@@ -16,7 +17,8 @@ function defaultObjectUsage() {
 }
 
 function alternateArrayUsage() {
-  const [t, i18n] = useTranslation();
+  const [t, i18n, ready] = useTranslation();
+  const r: boolean = ready;
   return (
     <div>
       {t('key1')} {i18n.exists('key1')}

--- a/test/typescript/withTranslation.test.tsx
+++ b/test/typescript/withTranslation.test.tsx
@@ -11,7 +11,8 @@ interface MyComponentProps extends WithTranslation {
 }
 
 const MyComponent = (props: MyComponentProps) => {
-  const { t, i18n } = props;
+  const { t, i18n, tReady } = props;
+  const r: boolean = tReady;
   return <h2>{t('title')}</h2>;
 };
 


### PR DESCRIPTION
Added a typing and some tests that appear to have been missed in a [previous feature](https://github.com/i18next/react-i18next/commit/a46263ed3f5bd4c84cb4353cbdcf2f1c34c79214).

- **Translation**: added typing for the _ready_ parameter and added a test to validate it.
- **useTranslation**: updated TypeScript tests to validate _ready_ return value
- **withTranslation**: updated TypeScript tests to validate _tReady_ prop (WithTranslation).
