### PR TITLE
fix useTranslation hook, stop breaking "Rules of Hooks", add checks for eslint.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,6 @@
 {
   "extends": ["airbnb", "prettier", "prettier/react"],
+  "plugins": ["react-hooks"],
   "parser": "babel-eslint",
   "parserOptions": {
     "ecmaVersion": 8,
@@ -94,6 +95,7 @@
         "aspects": ["invalidHref"]
       }
     ],
-    "react/jsx-props-no-spreading": 0
+    "react/jsx-props-no-spreading": 0,
+    "react-hooks/rules-of-hooks": 2
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "eslint-plugin-import": "2.18.2",
     "eslint-plugin-jsx-a11y": "6.2.3",
     "eslint-plugin-react": "7.16.0",
+    "eslint-plugin-react-hooks": "^2.3.0",
     "husky": "^3.0.3",
     "i18next": "^19.0.0",
     "jest": "24.8.0",

--- a/src/withTranslation.js
+++ b/src/withTranslation.js
@@ -28,7 +28,7 @@ export function withTranslation(ns, options = {}) {
     I18nextWithTranslation.WrappedComponent = WrappedComponent;
 
     const forwardRef = (props, ref) =>
-      React.createElement(I18nextWithTranslation, Object.assign({}, props, { forwardedRef: ref }));
+      React.createElement(I18nextWithTranslation, { ...props, forwardedRef: ref });
 
     return options.withRef ? React.forwardRef(forwardRef) : I18nextWithTranslation;
   };


### PR DESCRIPTION
The library is currently breaking the rules described in the React documentation.

https://reactjs.org/docs/hooks-rules.html

"Rules of Hooks" says :

> Don’t call Hooks inside loops, conditions, or nested functions. Instead, always use Hooks at the top level of your React function. By following this rule, you ensure that Hooks are called in the same order each time a component renders.

I fixed that and add checks "Rules of Hooks" in eslint.
