### PR TITLE
Add sideEffects false to package json to allow tree shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,5 +147,6 @@
       "**/react-i18next.min.js"
     ]
   },
-  "lock": false
+  "lock": false,
+  "sideEffects": false
 }


### PR DESCRIPTION
Noticed that all the exports were being included output bundles even though only a few were used.

This pr adds `sideEffects: false` to the `package.json` so that bundlers like webpack can tree shaking unused code. 

BEFORE:
<img width="1052" alt="Screenshot 2020-04-23 at 09 01 17" src="https://user-images.githubusercontent.com/1841819/80075946-55fa6e00-8543-11ea-9779-eec822193542.png">

AFTER:
<img width="1391" alt="Screenshot 2020-04-23 at 09 21 17" src="https://user-images.githubusercontent.com/1841819/80076345-fb154680-8543-11ea-9548-3e73b0afaae4.png">

