### PR TITLE
refactor(context): remove redundant check `hasUsedI18nextProvider`

### DIFF
--- a/src/I18nextProvider.js
+++ b/src/I18nextProvider.js
@@ -1,10 +1,8 @@
-import React from 'react';
-import { I18nContext, usedI18nextProvider } from './context';
+import { createElement } from 'react';
+import { I18nContext } from './context';
 
 export function I18nextProvider({ i18n, defaultNS, children }) {
-  usedI18nextProvider(true);
-
-  return React.createElement(
+  return createElement(
     I18nContext.Provider,
     {
       value: {

--- a/src/Trans.js
+++ b/src/Trans.js
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import HTML from 'html-parse-stringify2';
-import { getI18n, getHasUsedI18nextProvider, I18nContext, getDefaults } from './context';
+import { getI18n, I18nContext, getDefaults } from './context';
 import { warn, warnOnce } from './utils';
 
 function hasChildren(node) {
@@ -215,11 +215,9 @@ export function Trans({
   t: tFromProps,
   ...additionalProps
 }) {
-  const ReactI18nContext = useContext(I18nContext);
-  const { i18n: i18nFromContext, defaultNS: defaultNSFromContext } = getHasUsedI18nextProvider()
-    ? ReactI18nContext || {}
-    : {};
+  const { i18n: i18nFromContext, defaultNS: defaultNSFromContext } = useContext(I18nContext) || {};
   const i18n = i18nFromProps || i18nFromContext || getI18n();
+
   if (!i18n) {
     warnOnce('You will need pass in an i18next instance by using i18nextReactModule');
     return children;

--- a/src/context.js
+++ b/src/context.js
@@ -12,17 +12,8 @@ let defaultOptions = {
 };
 
 let i18nInstance;
-let hasUsedI18nextProvider;
 
 export const I18nContext = React.createContext();
-
-export function usedI18nextProvider(used) {
-  hasUsedI18nextProvider = used;
-}
-
-export function getHasUsedI18nextProvider() {
-  return hasUsedI18nextProvider;
-}
 
 export function setDefaults(options = {}) {
   defaultOptions = { ...defaultOptions, ...options };

--- a/src/useSSR.js
+++ b/src/useSSR.js
@@ -1,10 +1,9 @@
 import { useContext } from 'react';
-import { getI18n, getHasUsedI18nextProvider, I18nContext } from './context';
+import { getI18n, I18nContext } from './context';
 
 export function useSSR(initialI18nStore, initialLanguage, props = {}) {
   const { i18n: i18nFromProps } = props;
-  const ReactI18nContext = useContext(I18nContext);
-  const { i18n: i18nFromContext } = getHasUsedI18nextProvider() ? ReactI18nContext || {} : {};
+  const { i18n: i18nFromContext } = useContext(I18nContext) || {};
   const i18n = i18nFromProps || i18nFromContext || getI18n();
 
   // opt out if is a cloned instance, eg. created by i18next-http-middleware on request

--- a/src/useTranslation.js
+++ b/src/useTranslation.js
@@ -1,20 +1,11 @@
 import { useState, useEffect, useContext, useRef } from 'react';
-import {
-  getI18n,
-  getDefaults,
-  ReportNamespaces,
-  getHasUsedI18nextProvider,
-  I18nContext,
-} from './context';
+import { getI18n, getDefaults, ReportNamespaces, I18nContext } from './context';
 import { warnOnce, loadNamespaces, hasLoadedNamespace } from './utils';
 
 export function useTranslation(ns, props = {}) {
   // assert we have the needed i18nInstance
   const { i18n: i18nFromProps } = props;
-  const ReactI18nContext = useContext(I18nContext);
-  const { i18n: i18nFromContext, defaultNS: defaultNSFromContext } = getHasUsedI18nextProvider()
-    ? ReactI18nContext || {}
-    : {};
+  const { i18n: i18nFromContext, defaultNS: defaultNSFromContext } = useContext(I18nContext) || {};
   const i18n = i18nFromProps || i18nFromContext || getI18n();
   if (i18n && !i18n.reportNamespaces) i18n.reportNamespaces = new ReportNamespaces();
   if (!i18n) {
@@ -53,7 +44,7 @@ export function useTranslation(ns, props = {}) {
   const isMounted = useRef(true);
   useEffect(() => {
     const { bindI18n, bindI18nStore } = i18nOptions;
-    isMounted.current = true
+    isMounted.current = true;
 
     // if not ready and not using suspense load the namespaces
     // in side effect and do not call resetT if unmounted

--- a/test/useTranslation.spec.js
+++ b/test/useTranslation.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import i18nInstance from './i18n';
 import { useTranslation } from '../src/useTranslation';
-import { setI18n, usedI18nextProvider } from '../src/context';
+import { setI18n } from '../src/context';
 import { I18nextProvider } from '../src/I18nextProvider';
 
 jest.unmock('../src/useTranslation');
@@ -119,10 +119,6 @@ describe('useTranslation', () => {
 
       return <div>{t('key1')}</div>;
     }
-
-    beforeEach(() => {
-      usedI18nextProvider(false);
-    });
 
     afterEach(() => {
       i18nInstance.reportNamespaces.usedNamespaces = {};


### PR DESCRIPTION
There is no need for `getHasUsedI18nextProvider`
If `I18nContext.Provider` was used then `useContext(I18nContext`) will return a value.
In cases when user overrided `I18nContext.Provider` value we fallback to an empty object `useContext(I18nContext) || {}`