### PR TITLE
Added lodash and merge option in mapAST

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",
-    "html-parse-stringify2": "2.0.1",
-    "lodash.merge": "^4.6.2"
+    "html-parse-stringify2": "2.0.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@babel/runtime": "^7.3.1",
     "html-parse-stringify2": "2.0.1",
-    "lodash": "^4.17.15"
+    "lodash.merge": "^4.6.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",
-    "html-parse-stringify2": "2.0.1"
+    "html-parse-stringify2": "2.0.1",
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",

--- a/src/Trans.js
+++ b/src/Trans.js
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import HTML from 'html-parse-stringify2';
-import _ from 'lodash';
+import merge from 'lodash.merge';
 import { getI18n, I18nContext, getDefaults } from './context';
 import { warn, warnOnce } from './utils';
 
@@ -134,7 +134,7 @@ function renderNodes(children, targetString, i18n, i18nOptions, combinedTOpts) {
       const translationContent = node.children && node.children[0] && node.children[0].content;
       if (node.type === 'tag') {
         const tmp = reactNodes[parseInt(node.name, 10)] || {};
-        const child = Object.keys(node.attrs).length !== 0 ? _.merge({props: node.attrs}, tmp) : tmp;
+        const child = Object.keys(node.attrs).length !== 0 ? merge({props: node.attrs}, tmp) : tmp;
 
         const isElement = React.isValidElement(child);
 

--- a/src/Trans.js
+++ b/src/Trans.js
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react';
 import HTML from 'html-parse-stringify2';
-import merge from 'lodash.merge';
 import { getI18n, I18nContext, getDefaults } from './context';
 import { warn, warnOnce } from './utils';
 
@@ -23,10 +22,10 @@ function getAsArray(data) {
 }
 
 function mergeProps(source, target){
-  let new_target = {...target};
+  const newTarget = {...target};
   // overwrite source.props when target.props already set
-  new_target.props = Object.assign(source.props, target.props);
-  return new_target;
+  newTarget.props = Object.assign(source.props, target.props);
+  return newTarget;
 }
 
 export function nodesToString(children, i18nOptions) {

--- a/src/Trans.js
+++ b/src/Trans.js
@@ -134,7 +134,7 @@ function renderNodes(children, targetString, i18n, i18nOptions, combinedTOpts) {
       const translationContent = node.children && node.children[0] && node.children[0].content;
       if (node.type === 'tag') {
         const tmp = reactNodes[parseInt(node.name, 10)] || {};
-        const child = Object.keys(node.attrs).length != 0 ? _.merge({props: node.attrs}, tmp) : tmp;
+        const child = Object.keys(node.attrs).length !== 0 ? _.merge({props: node.attrs}, tmp) : tmp;
 
         const isElement = React.isValidElement(child);
 

--- a/src/Trans.js
+++ b/src/Trans.js
@@ -22,6 +22,13 @@ function getAsArray(data) {
   return Array.isArray(data) ? data : [data];
 }
 
+function mergeProps(source, target){
+  let new_target = {...target};
+  // overwrite source.props when target.props already set
+  new_target.props = Object.assign(source.props, target.props);
+  return new_target;
+}
+
 export function nodesToString(children, i18nOptions) {
   if (!children) return '';
   let stringNode = '';
@@ -134,7 +141,7 @@ function renderNodes(children, targetString, i18n, i18nOptions, combinedTOpts) {
       const translationContent = node.children && node.children[0] && node.children[0].content;
       if (node.type === 'tag') {
         const tmp = reactNodes[parseInt(node.name, 10)] || {};
-        const child = Object.keys(node.attrs).length !== 0 ? merge({props: node.attrs}, tmp) : tmp;
+        const child = Object.keys(node.attrs).length !== 0 ? mergeProps({props: node.attrs}, tmp) : tmp;
 
         const isElement = React.isValidElement(child);
 

--- a/src/Trans.js
+++ b/src/Trans.js
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import HTML from 'html-parse-stringify2';
+import _ from 'lodash';
 import { getI18n, I18nContext, getDefaults } from './context';
 import { warn, warnOnce } from './utils';
 
@@ -132,7 +133,9 @@ function renderNodes(children, targetString, i18n, i18nOptions, combinedTOpts) {
     return astNodes.reduce((mem, node, i) => {
       const translationContent = node.children && node.children[0] && node.children[0].content;
       if (node.type === 'tag') {
-        const child = reactNodes[parseInt(node.name, 10)] || {};
+        const tmp = reactNodes[parseInt(node.name, 10)] || {};
+        const child = Object.keys(node.attrs).length != 0 ? _.merge({props: node.attrs}, tmp) : tmp;
+
         const isElement = React.isValidElement(child);
 
         if (typeof child === 'string') {

--- a/test/i18n.js
+++ b/test/i18n.js
@@ -39,6 +39,7 @@ i18n.init({
         testTrans4KeyWithNestedComponent: 'Result should be a list: <0></0>',
         testTrans5KeyWithNestedComponent: 'Result should be a list: <1></1>',
         testTrans5KeyWithValue: 'Result should be rendered within tag <0>{{testValue}}</0>',
+		transTest3: 'Result should be a clickable link <0 href="https://www.google.com">Google</0>',
       },
       other: {
         transTest1: 'Another go <1>there</1>.',

--- a/test/i18n.js
+++ b/test/i18n.js
@@ -40,6 +40,7 @@ i18n.init({
         testTrans5KeyWithNestedComponent: 'Result should be a list: <1></1>',
         testTrans5KeyWithValue: 'Result should be rendered within tag <0>{{testValue}}</0>',
 		transTest3: 'Result should be a clickable link <0 href="https://www.google.com">Google</0>',
+		transTest3_overwrite: 'Result should be a clickable link <0 href="https://www.google.com">Google</0>',
       },
       other: {
         transTest1: 'Another go <1>there</1>.',

--- a/test/trans.render.spec.js
+++ b/test/trans.render.spec.js
@@ -99,7 +99,7 @@ describe('trans using translation prop', () => {
 
   it('should render correct content', () => {
     const wrapper = mount(<TestElement />);
-    console.log(wrapper.debug());
+    // console.log(wrapper.debug());
     expect(
       wrapper.contains(
         <div>
@@ -119,7 +119,7 @@ describe('trans overwrites translation prop', () => {
 
   it('should render correct content', () => {
     const wrapper = mount(<TestElement />);
-    console.log(wrapper.debug());
+    // console.log(wrapper.debug());
     expect(
       wrapper.contains(
         <div>

--- a/test/trans.render.spec.js
+++ b/test/trans.render.spec.js
@@ -79,7 +79,7 @@ describe('trans simple using ns prop', () => {
 
   it('should render correct content', () => {
     const wrapper = mount(<TestElement />);
-    // console.log(wrapper.debug());
+   	console.log(wrapper.debug());
     expect(
       wrapper.contains(
         <div>

--- a/test/trans.render.spec.js
+++ b/test/trans.render.spec.js
@@ -72,7 +72,27 @@ describe('trans simple', () => {
 
 describe('trans simple using ns prop', () => {
   const TestElement = ({ parent }) => (
-    <Trans i18nKey="transTest1" ns="other" parent={parent}>
+    <Trans i18nKey="transTest1" parent={parent}>
+      <a>here</a>.
+    </Trans>
+  );
+
+  it('should render correct content', () => {
+    const wrapper = mount(<TestElement />);
+    // console.log(wrapper.debug());
+    expect(
+      wrapper.contains(
+        <div>
+		  Result should be a clickable link <a href="https://www.google.com">Google</a>.
+        </div>,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('trans using translation prop', () => {
+  const TestElement = ({ parent }) => (
+    <Trans i18nKey="transTest3" ns="other" parent={parent}>
       Open <Link to="/msgs">here</Link>.
     </Trans>
   );

--- a/test/trans.render.spec.js
+++ b/test/trans.render.spec.js
@@ -103,7 +103,27 @@ describe('trans using translation prop', () => {
     expect(
       wrapper.contains(
         <div>
-          Result should be a clickable link <a href="https://www.google.com">Google</a>.
+          Result should be a clickable link <a href="https://www.google.com">Google</a>
+        </div>,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('trans overwrites translation prop', () => {
+  const TestElement = ({ parent }) => (
+    <Trans i18nKey="transTest3_overwrite" parent={parent}>
+      <a href="https://www.bing.com"></a>
+    </Trans>
+  );
+
+  it('should render correct content', () => {
+    const wrapper = mount(<TestElement />);
+    console.log(wrapper.debug());
+    expect(
+      wrapper.contains(
+        <div>
+          Result should be a clickable link <a href="https://www.bing.com">Google</a>
         </div>,
       ),
     ).toBe(true);

--- a/test/trans.render.spec.js
+++ b/test/trans.render.spec.js
@@ -72,27 +72,7 @@ describe('trans simple', () => {
 
 describe('trans simple using ns prop', () => {
   const TestElement = ({ parent }) => (
-    <Trans i18nKey="transTest1" parent={parent}>
-      <a>here</a>.
-    </Trans>
-  );
-
-  it('should render correct content', () => {
-    const wrapper = mount(<TestElement />);
-   	console.log(wrapper.debug());
-    expect(
-      wrapper.contains(
-        <div>
-		  Result should be a clickable link <a href="https://www.google.com">Google</a>.
-        </div>,
-      ),
-    ).toBe(true);
-  });
-});
-
-describe('trans using translation prop', () => {
-  const TestElement = ({ parent }) => (
-    <Trans i18nKey="transTest3" ns="other" parent={parent}>
+    <Trans i18nKey="transTest1" ns="other" parent={parent}>
       Open <Link to="/msgs">here</Link>.
     </Trans>
   );
@@ -104,6 +84,26 @@ describe('trans using translation prop', () => {
       wrapper.contains(
         <div>
           Another go <Link to="/msgs">there</Link>.
+        </div>,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('trans using translation prop', () => {
+  const TestElement = ({ parent }) => (
+    <Trans i18nKey="transTest3" parent={parent}>
+      <a></a>
+    </Trans>
+  );
+
+  it('should render correct content', () => {
+    const wrapper = mount(<TestElement />);
+    console.log(wrapper.debug());
+    expect(
+      wrapper.contains(
+        <div>
+          Result should be a clickable link <a href="https://www.google.com">Google</a>.
         </div>,
       ),
     ).toBe(true);


### PR DESCRIPTION
Dear maintainers of react-i18next,

Below is my pull request for #1117 where I initially requested the option to have props within a `<0 ...props></0>` passed to its final component. It is a very simple fix. 

I have tried running `npm run test` but it seems the distribution lacks `dtslint/dtslint.json` - I have tested the code extensively and don't see any issues that may occur. 

I also wasn't sure where to change the documentation. If you point me in the right direction I will adapt where necessary. 

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [ ] documentation is changed or added