### PR TITLE
Fix typo in withTranslation() example.

### DIFF
--- a/example/react/src/App.js
+++ b/example/react/src/App.js
@@ -6,7 +6,7 @@ import './App.css';
 // use hoc for class based components
 class LegacyWelcomeClass extends Component {
   render() {
-    const { t } = this.props;
+    const { t } = this.props.t;
     return <h2>{t('title')}</h2>;
   }
 }


### PR DESCRIPTION
`const { t } = this.props` leads to error. `t` should be derived from `this.props.t`.

No unit test or documentation added since this is in example code.

#### Checklist

- [ V ] only relevant code is changed (make a diff before you submit the PR)
- [ V ] run tests `npm run test`
- [ X ] tests are included
- [ X ] documentation is changed or added