### PR TITLE
providing filename when running babel.parse in icu.macro

### DIFF
--- a/icu.macro.js
+++ b/icu.macro.js
@@ -53,6 +53,7 @@ function ICUMacro({ references, state, babel }) {
           children: referencePath.parentPath.parentPath.get('children'),
         },
         babel,
+        state,
       );
     } else {
       // throw a helpful error message or something :)
@@ -174,7 +175,7 @@ function selectAsJSX(parentPath, { attributes }, babel) {
   parentPath.replaceWith(buildTransElement(extracted, extracted.attributesToCopy, t, true));
 }
 
-function transAsJSX(parentPath, { attributes, children }, babel) {
+function transAsJSX(parentPath, { attributes, children }, babel, { filename }) {
   const defaultsAttr = findAttribute('defaults', attributes);
   const componentsAttr = findAttribute('components', attributes);
   // if there is "defaults" attribute and no "components" attribute, parse defaults and extract from the parsed defaults instead of children
@@ -186,6 +187,7 @@ function transAsJSX(parentPath, { attributes, children }, babel) {
     const defaultsExpression = defaultsAttr.node.value.value;
     const parsed = babel.parse(`<>${defaultsExpression}</>`, {
       presets: ['@babel/react'],
+      filename,
     }).program.body[0].expression.children;
 
     extracted = processTrans(parsed, babel);


### PR DESCRIPTION
We've been using icu.macro just fine at our organization for a while now. 
Very recently, we started implementing typescript support for our org, and this brought to light a little issue with the macro. 

```FAIL packages/locale/src/PluralsAndGenders.test.js
  ● Test suite failed to run
    /Users/joeycozza/fs/zion/packages/locale/src/PluralsAndGenders.stories.js: react-i18next/icu.macro: [BABEL] unknown: Preset /* your preset */ requires a filename to be set when babel is called directly,
    ```
    babel.transform(code, { filename: 'file.ts', presets: [/* your preset */] });
    ```
    See https://babeljs.io/docs/en/options#filename for more information. Learn more: https://www.npmjs.com/package/react-i18next
      at validateIfOptionNeedsFilename (node_modules/@babel/core/lib/config/full.js:274:11)
      at node_modules/@babel/core/lib/config/full.js:286:52
          at Array.forEach (<anonymous>)
      at validatePreset (node_modules/@babel/core/lib/config/full.js:286:25)
      at loadPresetDescriptor (node_modules/@babel/core/lib/config/full.js:293:3)
          at loadPresetDescriptor.next (<anonymous>)
      at recurseDescriptors (node_modules/@babel/core/lib/config/full.js:107:30)
          at recurseDescriptors.next (<anonymous>)
      at loadFullConfig (node_modules/@babel/core/lib/config/full.js:142:6)
          at loadFullConfig.next (<anonymous>)
```

It is a fairly simple fix, we just need to provide the filename to `babel.parse` when it is called explicitly.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [ ] documentation is changed or added