### PR TITLE
feat: Trans interpolating self-closing tags in components prop(object)

### DIFF
--- a/src/Trans.js
+++ b/src/Trans.js
@@ -135,6 +135,17 @@ function renderNodes(children, targetString, i18n, i18nOptions, combinedTOpts) {
   // -> avoids issues in parser removing prepending text nodes
   const ast = HTML.parse(`<0>${interpolatedString}</0>`);
 
+  function pushTranslatedJSX(child, node, rootReactNode, mem, i) {
+    const childs = getChildren(child);
+    const mappedChildren = mapAST(childs, node.children, rootReactNode);
+    // console.warn('INNER', node.name, node, child, childs, node.children, mappedChildren);
+    const inner =
+      hasValidReactChildren(childs) && mappedChildren.length === 0 ? childs : mappedChildren;
+
+    if (child.dummy) child.children = inner; // needed on preact!
+    mem.push(React.cloneElement(child, { ...child.props, key: i }, inner));
+  }
+
   // reactNode (the jsx root element or child)
   // astNode (the translation string as html ast)
   // rootReactNode (the most outer jsx children array or trans components prop)
@@ -154,28 +165,27 @@ function renderNodes(children, targetString, i18n, i18nOptions, combinedTOpts) {
           Object.keys(node.attrs).length !== 0 ? mergeProps({ props: node.attrs }, tmp) : tmp;
 
         const isElement = React.isValidElement(child);
+
+        const isValidTranslationWithChildren =
+          isElement && hasChildren(node, true) && !node.voidElement;
+
+        const isEmptyTransWithHTML =
+          emptyChildrenButNeedsHandling && typeof child === 'object' && child.dummy && !isElement;
+
+        const isKnownComponent =
+          typeof children === 'object' &&
+          children !== null &&
+          Object.hasOwnProperty.call(children, node.name);
         // console.warn('CHILD', node.name, node, isElement, child);
 
         if (typeof child === 'string') {
           mem.push(child);
         } else if (
           hasChildren(child) || // the jsx element has children -> loop
-          (isElement && hasChildren(node, true) && !node.voidElement) // valid jsx element with no children but the translation has -> loop
+          isValidTranslationWithChildren // valid jsx element with no children but the translation has -> loop
         ) {
-          const childs = getChildren(child);
-          const mappedChildren = mapAST(childs, node.children, rootReactNode);
-          // console.warn('INNER', node.name, node, child, childs, node.children, mappedChildren);
-          const inner =
-            hasValidReactChildren(childs) && mappedChildren.length === 0 ? childs : mappedChildren;
-
-          if (child.dummy) child.children = inner; // needed on preact!
-          mem.push(React.cloneElement(child, { ...child.props, key: i }, inner));
-        } else if (
-          emptyChildrenButNeedsHandling &&
-          typeof child === 'object' &&
-          child.dummy &&
-          !isElement
-        ) {
+          pushTranslatedJSX(child, node, rootReactNode, mem, i);
+        } else if (isEmptyTransWithHTML) {
           // we have a empty Trans node (the dummy element) with a targetstring that contains html tags needing
           // conversion to react nodes
           // so we just need to map the inner stuff
@@ -186,7 +196,9 @@ function renderNodes(children, targetString, i18n, i18nOptions, combinedTOpts) {
           );
           mem.push(React.cloneElement(child, { ...child.props, key: i }, inner));
         } else if (Number.isNaN(parseFloat(node.name))) {
-          if (i18nOptions.transSupportBasicHtmlNodes && keepArray.indexOf(node.name) > -1) {
+          if (isKnownComponent) {
+            pushTranslatedJSX(child, node, rootReactNode, mem, i);
+          } else if (i18nOptions.transSupportBasicHtmlNodes && keepArray.indexOf(node.name) > -1) {
             if (node.voidElement) {
               mem.push(React.createElement(node.name, { key: `${node.name}-${i}` }));
             } else {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -33,7 +33,7 @@ export interface TransProps<E extends Element = HTMLDivElement>
   extends React.HTMLProps<E>,
     Partial<WithT> {
   children?: React.ReactNode;
-  components?: readonly React.ReactNode[];
+  components?: readonly React.ReactNode[] | { [tagName: string]: React.ReactNode };
   count?: number;
   defaults?: string;
   i18n?: i18n;

--- a/test/trans.render.object.spec.js
+++ b/test/trans.render.object.spec.js
@@ -115,3 +115,51 @@ describe('trans using no children but components (object) - use more than once (
     ).toBe(true);
   });
 });
+
+describe('trans using no children but components (object) - using self closing tag', () => {
+  const Button = () => <button type="button">click me</button>;
+  const TestElement = () => (
+    <Trans defaults="hello <ClickMe />" components={{ ClickMe: <Button /> }} />
+  );
+  it('should render translated string', () => {
+    const wrapper = mount(<TestElement />);
+    // console.log(wrapper.debug());
+    expect(wrapper.contains(<button type="button">click me</button>)).toBe(true);
+  });
+});
+
+describe('trans using no children but components (object) - empty content', () => {
+  const Button = () => <button type="button">click me</button>;
+  const TestElement = () => (
+    <Trans defaults="hello <ClickMe></ClickMe>" components={{ ClickMe: <Button /> }} />
+  );
+  it('should render translated string', () => {
+    const wrapper = mount(<TestElement />);
+    // console.log(wrapper.debug());
+    expect(wrapper.contains(<button type="button">click me</button>)).toBe(true);
+  });
+});
+
+describe('trans using children but components (object) - self closing tag', () => {
+  const Button = () => <button type="button">click me</button>;
+  const TestElement = () => (
+    <Trans components={{ ClickMe: <Button /> }}>{'hello <ClickMe/>'}</Trans>
+  );
+  it('should render translated string', () => {
+    const wrapper = mount(<TestElement />);
+    // console.log(wrapper.debug());
+    expect(wrapper.contains(<button type="button">click me</button>)).toBe(true);
+  });
+});
+
+describe('trans using no children but components (object) - interpolated component with children', () => {
+  const Button = ({ children }) => <button type="button">{children}</button>;
+  const TestElement = () => (
+    <Trans defaults="hello <ClickMe>Test</ClickMe>" components={{ ClickMe: <Button /> }} />
+  );
+  it('should render translated string', () => {
+    const wrapper = mount(<TestElement />);
+    // console.log(wrapper.debug());
+    expect(wrapper.contains(<button type="button">Test</button>)).toBe(true);
+  });
+});

--- a/test/typescript/Trans.test.tsx
+++ b/test/typescript/Trans.test.tsx
@@ -22,6 +22,10 @@ function constComponents() {
   return <Trans components={constArray}>Foo</Trans>;
 }
 
+function objectComponents() {
+  return <Trans components={{ Btn: <button /> }} defaults="Hello <Btn />" />;
+}
+
 function count() {
   return <Trans count={42}>Foo</Trans>;
 }
@@ -60,10 +64,8 @@ function t() {
   return <Trans t={t}>Foo</Trans>;
 }
 
-function CustomRedComponent(props: {children: React.ReactNode}) {
-  return <div style={{color: 'red'}}>
-    {props.children}
-  </div>;
+function CustomRedComponent(props: { children: React.ReactNode }) {
+  return <div style={{ color: 'red' }}>{props.children}</div>;
 }
 
 function extraDivProps() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->
This PR intends to close #1136. It provides:
1. More versatility to the Trans component as now is possible to interpolate self-closing tags
2. Updated Trans typing, reflecting the alternative usage described in [docs](https://react.i18next.com/latest/trans-component#alternative-usage-v-11-6-0).
3. Improved readability on `mapAst`'s reducer.

The third point is opinionated, but I was having trouble to reason with it the way it was written. 
I was also forced to write the `pushTranslatedJSX` function (still unsure if this is the best name though) to keep the DRY principle. 

#### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [X] run tests `npm run test`
- [X] tests are included
- [X] documentation is changed or added