### PR TITLE
Fixed typescript module

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -18,17 +18,6 @@ export function getInitialProps(): {
   initialLanguage: string;
 };
 
-export interface ReportNamespaces {
-  addUsedNamespaces(namespaces: Namespace[]): void;
-  getUsedNamespaces(): string[];
-}
-
-declare module 'i18next' {
-  interface i18n {
-    reportNamespaces: ReportNamespaces;
-  }
-}
-
 export interface TransProps<E extends Element = HTMLDivElement>
   extends React.HTMLProps<E>,
     Partial<WithT> {

--- a/test/typescript/context.test.tsx
+++ b/test/typescript/context.test.tsx
@@ -34,6 +34,3 @@ i18n.setDefaultNamespace;
 i18n.store;
 i18n.t;
 i18n.use;
-// To be reviewed: No reference found in official documentation.
-// i18next.reportNamespaces.addUsedNamespaces(['translation']);
-// i18next.reportNamespaces.getUsedNamespaces();

--- a/test/typescript/context.test.tsx
+++ b/test/typescript/context.test.tsx
@@ -1,4 +1,39 @@
-import i18next from 'i18next';
+import i18n from './i18n';
 
-i18next.reportNamespaces.addUsedNamespaces(['translation']);
-i18next.reportNamespaces.getUsedNamespaces();
+// All keys should be here
+i18n.addResource;
+i18n.addResourceBundle;
+i18n.addResources;
+i18n.changeLanguage;
+i18n.cloneInstance;
+i18n.createInstance;
+i18n.dir;
+i18n.emit;
+i18n.exists;
+i18n.format;
+i18n.getDataByLanguage;
+i18n.getFixedT;
+i18n.getResource;
+i18n.getResourceBundle;
+i18n.hasResourceBundle;
+i18n.init;
+i18n.isInitialized;
+i18n.language;
+i18n.languages;
+i18n.loadLanguages;
+i18n.loadNamespaces;
+i18n.loadResources;
+i18n.modules;
+i18n.off;
+i18n.on;
+i18n.options;
+i18n.reloadResources;
+i18n.removeResourceBundle;
+i18n.services;
+i18n.setDefaultNamespace;
+i18n.store;
+i18n.t;
+i18n.use;
+// To be reviewed: No reference found in official documentation.
+// i18next.reportNamespaces.addUsedNamespaces(['translation']);
+// i18next.reportNamespaces.getUsedNamespaces();


### PR DESCRIPTION
In the PR #945, the module was overriden, Typescript could not see any of the keys defined in `i18next.i18n`.

Only the following properties these two properties were accessible: `reportNamespaces`, `reportNamespaces`.

Since I could not find any documentation about these two methods, I've decided to remove the module override.

#### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [X] run tests `npm run test`
- [X] tests are included
-  [ ] documentation is changed or added (NA)