### PR TITLE
Avoid setState while react is rendering

### DIFF
--- a/src/useTranslation.js
+++ b/src/useTranslation.js
@@ -85,7 +85,6 @@ export function useTranslation(ns, props = {}) {
   // not yet loaded namespaces -> load them -> and trigger suspense
   throw new Promise(resolve => {
     loadNamespaces(i18n, namespaces, () => {
-      if (isMounted.current) setT(getT());
       resolve();
     });
   });


### PR DESCRIPTION
As documented in [my comment about issue #1124](https://github.com/i18next/react-i18next/issues/1124#issuecomment-680153621), this fix should avoid `setState` while react is rendering.

See #1124 for more details.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
-  ~tests are included~
-  ~documentation is changed or added~