### PR TITLE
Make the translation function fully type-safe

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+# Prettier does not support typescript 4.1 syntax yet.
+# Once they support it, we can remove this line.
+# https://github.com/prettier/prettier/issues/9234
+src/ts4.1/index.d.ts

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "typesVersions": {
     ">=4.1": {
       "*": [
-        "src/ts4.1/*"
+        "src/ts4.1/index.d.ts"
       ]
     }
   },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,13 @@
   "description": "Internationalization for react done right. Using the i18next i18n ecosystem.",
   "main": "dist/commonjs/index.js",
   "types": "src/index.d.ts",
+  "typesVersions": {
+    ">=4.1": {
+      "*": [
+        "src/ts4.1/*"
+      ]
+    }
+  },
   "jsnext:main": "dist/es/index.js",
   "module": "dist/es/index.js",
   "keywords": [

--- a/src/ts4.1/index.d.ts
+++ b/src/ts4.1/index.d.ts
@@ -101,7 +101,7 @@ export interface TFunction<N extends Namespace> {
 export interface TransProps<N extends Namespace, K extends TFuncKey<N>, E extends Element = HTMLDivElement>
   extends React.HTMLProps<E> {
   children?: React.ReactNode;
-  components?: readonly React.ReactNode[] | { [tagName: string]: React.ReactNode };
+  components?: React.ReactNode[] | { [tagName: string]: React.ReactNode };
   count?: number;
   defaults?: string;
   i18n?: i18n;

--- a/src/ts4.1/index.d.ts
+++ b/src/ts4.1/index.d.ts
@@ -118,7 +118,7 @@ export function Trans<N extends Namespace, K extends TFuncKey<N>, E extends Elem
   props: TransProps<N, K, E>
 ): React.ReactElement;
 
-export function useSSR(initialI18nStore: any, initialLanguage: any): void;
+export function useSSR(initialI18nStore: Resource, initialLanguage: string): void;
 
 export interface UseTranslationOptions {
   i18n?: i18n;
@@ -178,7 +178,7 @@ export interface I18nextProviderProps {
 }
 
 export const I18nextProvider: React.FunctionComponent<I18nextProviderProps>;
-export const I18nContext: React.Context<i18n>;
+export const I18nContext: React.Context<{ i18n: i18n }>;
 
 export interface TranslationProps<N extends Namespace> {
   children: (

--- a/src/ts4.1/index.d.ts
+++ b/src/ts4.1/index.d.ts
@@ -6,8 +6,6 @@ import * as React from 'react';
  */
 export interface Resources {}
 
-type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
-
 type ResourcesKey<T = keyof Resources> = [T] extends [never] ? string : T;
 
 export type Namespace = ResourcesKey | ResourcesKey[];

--- a/src/ts4.1/index.d.ts
+++ b/src/ts4.1/index.d.ts
@@ -1,0 +1,196 @@
+import i18next, { ReactOptions, i18n, ThirdPartyModule, Resource, TOptions, StringMap } from 'i18next';
+import * as React from 'react';
+
+/**
+ * This interface can be augmented by users to add types to `react-i18next` default resources.
+ */
+export interface Resources {}
+
+type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+
+type ResourcesKey<T = keyof Resources> = [T] extends [never] ? string : T;
+
+export type Namespace = ResourcesKey | ResourcesKey[];
+
+export function setDefaults(options: ReactOptions): void;
+export function getDefaults(): ReactOptions;
+export function setI18n(instance: i18n): void;
+export function getI18n(): i18n;
+export const initReactI18next: ThirdPartyModule;
+export function composeInitialProps(ForComponent: any): (ctx: unknown) => Promise<any>;
+export function getInitialProps(): {
+  initialI18nStore: {
+    [ns: string]: {};
+  };
+  initialLanguage: string;
+};
+
+export interface ReportNamespaces {
+  addUsedNamespaces(namespaces: Namespace[]): void;
+  getUsedNamespaces(): string[];
+}
+
+declare module 'i18next' {
+  interface i18n {
+    reportNamespaces: ReportNamespaces;
+  }
+}
+
+// Normalize single namespace
+type OmitArrayProps<T> = Exclude<T, keyof any[]>;
+type AppendKeys<K1, K2> = `${K1 & string}.${OmitArrayProps<K2> & string}`;
+type Normalize2<T, K = keyof T> = K extends keyof T
+  ? T[K] extends object
+  ? AppendKeys<K, keyof T[K]> | AppendKeys<K, Normalize2<T[K]>>
+  : never
+  : never;
+type Normalize<T> = keyof T | Normalize2<T>;
+
+// Normalize multiple namespaces
+type UnionToIntersection<U> = (U extends any
+  ? (k: U) => void
+  : never) extends (k: infer I) => void
+  ? I
+  : never;
+type LastOf<T> = UnionToIntersection<
+  T extends any ? () => T : never
+> extends () => infer R
+  ? R
+  : never;
+type AppendNS<N, K> = `${N & string}:${K & string}`;
+type NormalizeMulti<T, U extends keyof T, L = LastOf<U>> = L extends U
+  ? AppendNS<L, Normalize<T[L]>> | NormalizeMulti<T, Exclude<U, L>>
+  : never;
+
+type NormalizeReturn<T, V> = V extends `${infer K}.${infer R}`
+  ? K extends keyof T
+  ? NormalizeReturn<T[K], R>
+  : never
+  : V extends keyof T
+  ? T[V]
+  : never;
+
+type NormalizeMultiReturn<T, V> = V extends `${infer N}:${infer R}`
+  ? N extends keyof T
+  ? NormalizeReturn<T[N], R>
+  : never
+  : never;
+
+export type TFuncKey<N, T = Resources> = N extends (keyof T)[]
+  ? NormalizeMulti<T, N[number]>
+  : N extends keyof T
+  ? Normalize<T[N]>
+  : string;
+
+export type TFuncReturn<N, P, T = Resources> = N extends (keyof T)[]
+  ? NormalizeMultiReturn<T, P>
+  : N extends keyof T
+  ? NormalizeReturn<T[N], P>
+  : string;
+
+export interface TFunction<N extends Namespace> {
+  <K extends TFuncKey<N>, TInterpolationMap extends object = StringMap>(
+    key: K,
+    options?: TOptions<TInterpolationMap> | string,
+  ): TFuncReturn<N, K>;
+  <K extends TFuncKey<N>, TInterpolationMap extends object = StringMap>(
+    key: K,
+    defaultValue?: string,
+    options?: TOptions<TInterpolationMap> | string,
+  ): TFuncReturn<N, K>;
+}
+
+export interface TransProps<N extends Namespace, K extends TFuncKey<N>, E extends Element = HTMLDivElement>
+  extends React.HTMLProps<E> {
+  children?: React.ReactNode;
+  components?: readonly React.ReactNode[] | { [tagName: string]: React.ReactNode };
+  count?: number;
+  defaults?: string;
+  i18n?: i18n;
+  i18nKey?: K;
+  ns?: N;
+  parent?: string | React.ComponentType<any> | null; // used in React.createElement if not null
+  tOptions?: {};
+  values?: {};
+  t?: TFunction<N>;
+}
+export function Trans<N extends Namespace, K extends TFuncKey<N>, E extends Element = HTMLDivElement>(
+  props: TransProps<N, K, E>
+): React.ReactElement;
+
+export function useSSR(initialI18nStore: any, initialLanguage: any): void;
+
+export interface UseTranslationOptions {
+  i18n?: i18n;
+  useSuspense?: boolean;
+}
+
+type UseTranslationResponse<N extends Namespace> = [TFunction<N>, i18n, boolean] & {
+  t: TFunction<N>;
+  i18n: i18n;
+  ready: boolean;
+};
+export function useTranslation<
+  N extends Namespace = Extract<ResourcesKey, 'translation'>
+>(
+  ns?: N,
+  options?: UseTranslationOptions
+): UseTranslationResponse<N>;
+
+// Need to see usage to improve this
+export function withSSR(): <Props>(
+  WrappedComponent: React.ComponentType<Props>,
+) => {
+  ({
+    initialI18nStore,
+    initialLanguage,
+    ...rest
+  }: {
+    initialI18nStore: Resource;
+    initialLanguage: string;
+  } & Props): React.FunctionComponentElement<Props>;
+  getInitialProps: (ctx: unknown) => Promise<any>;
+};
+
+export interface WithTranslation<N extends Namespace> {
+  t: TFunction<N>;
+  i18n: i18n;
+  tReady: boolean;
+}
+
+export interface WithTranslationProps {
+  i18n?: i18n;
+  useSuspense?: boolean;
+}
+
+export function withTranslation<N extends Namespace>(
+  ns?: N,
+  options?: {
+    withRef?: boolean;
+  },
+): <P extends WithTranslation<N>>(
+  component: React.ComponentType<P>,
+) => React.ComponentType<Omit<P, keyof WithTranslation<N>> & WithTranslationProps>;
+
+export interface I18nextProviderProps {
+  i18n: i18n;
+  defaultNS?: string;
+}
+
+export const I18nextProvider: React.FunctionComponent<I18nextProviderProps>;
+export const I18nContext: React.Context<i18n>;
+
+export interface TranslationProps<N extends Namespace> {
+  children: (
+    t: TFunction<N>,
+    options: {
+      i18n: i18n;
+      lng: string;
+    },
+    ready: boolean,
+  ) => React.ReactNode;
+  ns?: N;
+  i18n?: i18n;
+}
+
+export function Translation<N extends Namespace>(props: TranslationProps<N>): any;


### PR DESCRIPTION
With Typescript 4.1, now it is possible to use recursive conditional type and template literal string. This PR aims to make the `t` function fully typed and supporting single and multiple namespaces. It works with `useTranslation (hooks)`, `withTranslation (HoC)`, `Trans Component` and `Translation (render prop)`.

### How to use it
You just have to rely on type augmentation technique to override the default Resources with the resource language object.

**For example:**
```ts
 // src/i18n/config.ts
export const resourcesEN = {
  earnings: {
    header: {
      title: 'Earnings',
      subTitle: 'See your Earnings'
    },
    notes: 'Balance'
  }
};

i18n.use(initReactI18next).init({
  resources: {
    en: resourcesEN,
  },
});

```
Type augmentation
```ts
// @types/react-i18next/index.d.ts
import "react-i18next";
import resourcesEN from "../../src/i18n/config";

declare module "react-i18next" {
  type DefaultResources = typeof resourcesEN;
  interface Resources extends DefaultResources {}
}
```
And that's all!!! it works like magic!
I've prepared a few examples using `useTranslation`.

**Using single and multiple namespaces:**
[https://tsplay.dev/gWozjm](https://tsplay.dev/gWozjm)

**Array case within the resources JSON:**
[https://tsplay.dev/nmq0ZN](https://tsplay.dev/nmq0ZN)

**Without Namespace:**
[https://tsplay.dev/rw21xW](https://tsplay.dev/rw21xW)

Below is the diff of the changes that I made:
[https://gist.github.com/pedrodurek/b23c17bebd9619b0dc0651bc3949a82e/revisions#diff-7aa4473ede4abd9ec099e87fec67fd57afafaf39e05d493ab4533acc38547eb8](https://gist.github.com/pedrodurek/b23c17bebd9619b0dc0651bc3949a82e/revisions#diff-7aa4473ede4abd9ec099e87fec67fd57afafaf39e05d493ab4533acc38547eb8)

Let me know if you want me to change anything, thank you guys! I hope this can help everyone who relies on i18next and typescript.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [ ] documentation is changed or added