### PR TITLE
Accept const components prop for Trans.

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -33,7 +33,7 @@ export interface TransProps<E extends Element = HTMLDivElement>
   extends React.HTMLProps<E>,
     Partial<WithT> {
   children?: React.ReactNode;
-  components?: readonly React.ReactNode[] | { [tagName: string]: React.ReactNode };
+  components?: readonly React.ReactNode[] | { readonly [tagName: string]: React.ReactNode };
   count?: number;
   defaults?: string;
   i18n?: i18n;

--- a/src/ts4.1/index.d.ts
+++ b/src/ts4.1/index.d.ts
@@ -118,7 +118,7 @@ export interface TransProps<
   E extends Element = HTMLDivElement
 > extends React.HTMLProps<E> {
   children?: React.ReactNode;
-  components?: React.ReactNode[] | { [tagName: string]: React.ReactNode };
+  components?: readonly React.ReactNode[] | { readonly [tagName: string]: React.ReactNode };
   count?: number;
   defaults?: string;
   i18n?: i18n;

--- a/test/typescript/Trans.test.tsx
+++ b/test/typescript/Trans.test.tsx
@@ -26,6 +26,13 @@ function objectComponents() {
   return <Trans components={{ Btn: <button /> }} defaults="Hello <Btn />" />;
 }
 
+function constObjectComponents() {
+  const constObject = {
+    Btn: <button />,
+  } as const;
+  return <Trans components={constObject} defaults="Hello <Btn />" />;
+}
+
 function count() {
   return <Trans count={42}>Foo</Trans>;
 }


### PR DESCRIPTION
Typescript bug fix: the `components` prop of `Trans` does not need to be mutable as it won't be modified. I'm changing the types to reflect that. Note that it was already done previously for Typescript <4.1 for arrays.

#### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [X] run tests `npm run test`
- [X] tests are included
- [ ] documentation is changed or added