### PR TITLE
withTranslation() typing fix for defaultProps

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,6 +2,7 @@ import i18next, { ReactOptions, i18n, ThirdPartyModule, WithT, TFunction, Resour
 import * as React from 'react';
 
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+type Subtract<T extends K, K> = Omit<T, keyof K>;
 
 export type Namespace = string | string[];
 
@@ -92,9 +93,15 @@ export function withTranslation(
   options?: {
     withRef?: boolean;
   },
-): <P extends WithTranslation>(
-  component: React.ComponentType<P>,
-) => React.ComponentType<Omit<P, keyof WithTranslation> & WithTranslationProps>;
+): <
+  C extends React.ComponentType<React.ComponentProps<C> & WithTranslationProps>,
+  ResolvedProps = JSX.LibraryManagedAttributes<
+    C,
+    Subtract<React.ComponentProps<C>, WithTranslationProps>
+  >
+>(
+  component: C,
+) => React.ComponentType<Omit<ResolvedProps, keyof WithTranslation> & WithTranslationProps>;
 
 export interface I18nextProviderProps {
   i18n: i18n;

--- a/src/ts4.1/index.d.ts
+++ b/src/ts4.1/index.d.ts
@@ -9,6 +9,8 @@ import i18next, {
 } from 'i18next';
 import * as React from 'react';
 
+type Subtract<T extends K, K> = Omit<T, keyof K>;
+
 /**
  * This interface can be augmented by users to add types to `react-i18next` default resources.
  */
@@ -176,9 +178,15 @@ export function withTranslation<N extends Namespace = DefaultNamespace>(
   options?: {
     withRef?: boolean;
   },
-): <P extends WithTranslation<N>>(
-  component: React.ComponentType<P>,
-) => React.ComponentType<Omit<P, keyof WithTranslation<N>> & WithTranslationProps>;
+): <
+  C extends React.ComponentType<React.ComponentProps<C> & WithTranslationProps>,
+  ResolvedProps = JSX.LibraryManagedAttributes<
+    C,
+    Subtract<React.ComponentProps<C>, WithTranslationProps>
+  >
+>(
+  component: C,
+) => React.ComponentType<Omit<ResolvedProps, keyof WithTranslation<N>> & WithTranslationProps>;
 
 export interface I18nextProviderProps {
   i18n: i18n;

--- a/test/typescript/withTranslation.test.tsx
+++ b/test/typescript/withTranslation.test.tsx
@@ -10,16 +10,27 @@ interface MyComponentProps extends WithTranslation {
   bar: 'baz';
 }
 
+const defaultProps: Partial<MyComponentProps> = {
+  bar: 'baz',
+};
+
 const MyComponent = (props: MyComponentProps) => {
   const { t, i18n, tReady } = props;
   const r: boolean = tReady;
   return <h2>{t('title')}</h2>;
 };
 
+MyComponent.defaultProps = defaultProps;
+
 // page uses the hook
 function defaultUsage() {
   const ExtendedComponent = withTranslation()(MyComponent);
   return <ExtendedComponent bar="baz" />;
+}
+
+function defaultUsageWithDefaultProps() {
+  const ExtendedComponent = withTranslation()(MyComponent);
+  return <ExtendedComponent />;
 }
 
 /**


### PR DESCRIPTION
I experienced TS errors when I tried to define props interface for a component that was wrapped in `withTranslation()` and had `defaultProps`. 
 
```
interface IStepperProps extends WithTranslation {  
    isHeadless: boolean; 
    defaultStep: number;  
    isStepInvalid?: boolean;
    submitStep?: () => void;
}

class Stepper extends React.Component<IStepperProps, IStepperState> {
    static defaultProps: Partial<IStepperProps> = {
        isHeadless: true,
        defaultStep: 1,
    };
    
    (...)
} 

export default connect(mapStateToProps)(withTranslation()(Stepper));
```

The `isHeadless` and `defaultStep` props have been marked in the interface as non-optional because they were needed and always provided in `defaultProps`. But TypeScript complained if I didn't pass them in JSX for the component:

```
<Stepper>…</Stepper>

TS2739: Type '{ children: any[]; }' is missing the following properties from type 'Readonly<Pick<Pick<IStepperProps, "isHeadless" | "isStepInvalid" | "submitStep" | "defaultStep"> & WithTranslationProps, "i18n" | ... 6 more ... | "useSuspense">>': isHeadless, defaultStep 
```

After changing the `withTranslation()` typings in `index.d.ts`, [following this instruction](https://stackoverflow.com/questions/54486983/default-prop-types-through-a-higher-order-component#answer-54753991), `defaultProps` are handled properly. 

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [ ] documentation is changed or added (no need)