### PR TITLE
Add workaround to suppress infinite instantiation warning

### DIFF
--- a/src/ts4.1/index.d.ts
+++ b/src/ts4.1/index.d.ts
@@ -10,6 +10,14 @@ import i18next, {
 import * as React from 'react';
 
 /**
+ * Due to a limitation/bug on typescript 4.1 (https://github.com/microsoft/TypeScript/issues/41406), we added
+ * "extends infer A ? A : never" in a few places to suppress the error "Type instantiation is excessively deep and possibly infinite."
+ * on cases where users have more than 22 namespaces. Once the issue is fixed, we can remove all instances of workaround used.
+ *
+ * Reference of the bug reported: https://github.com/i18next/react-i18next/issues/1222
+ */
+
+/**
  * This interface can be augmented by users to add types to `react-i18next` default resources.
  */
 export interface Resources {}
@@ -94,7 +102,7 @@ export type TFuncReturn<N, TKeys, TDefaultResult, T = Resources> = [keyof Resour
 
 export interface TFunction<N extends Namespace = DefaultNamespace> {
   <
-    TKeys extends TFuncKey<N> | TemplateStringsArray,
+    TKeys extends TFuncKey<N> | TemplateStringsArray extends infer A ? A : never,
     TDefaultResult extends TFunctionResult = string,
     TInterpolationMap extends object = StringMap
   >(
@@ -102,7 +110,7 @@ export interface TFunction<N extends Namespace = DefaultNamespace> {
     options?: TOptions<TInterpolationMap> | string,
   ): TFuncReturn<N, TKeys, TDefaultResult>;
   <
-    TKeys extends TFuncKey<N> | TemplateStringsArray,
+    TKeys extends TFuncKey<N> | TemplateStringsArray extends infer A ? A : never,
     TDefaultResult extends TFunctionResult = string,
     TInterpolationMap extends object = StringMap
   >(
@@ -113,7 +121,7 @@ export interface TFunction<N extends Namespace = DefaultNamespace> {
 }
 
 export interface TransProps<
-  K extends TFuncKey<N>,
+  K extends TFuncKey<N> extends infer A ? A : never,
   N extends Namespace = DefaultNamespace,
   E extends Element = HTMLDivElement
 > extends React.HTMLProps<E> {
@@ -130,7 +138,7 @@ export interface TransProps<
   t?: TFunction<N>;
 }
 export function Trans<
-  K extends TFuncKey<N>,
+  K extends TFuncKey<N> extends infer A ? A : never,
   N extends Namespace = DefaultNamespace,
   E extends Element = HTMLDivElement
 >(props: TransProps<K, N, E>): React.ReactElement;

--- a/src/ts4.1/index.d.ts
+++ b/src/ts4.1/index.d.ts
@@ -22,9 +22,9 @@ import * as React from 'react';
  */
 export interface Resources {}
 
-type ResourcesKey<T = keyof Resources> = [T] extends [never] ? string : T;
+type Fallback<F, T = keyof Resources> = [T] extends [never] ? F : T;
 
-export type Namespace = ResourcesKey | ResourcesKey[];
+export type Namespace<F = Fallback<string>> = F | F[];
 
 export function setDefaults(options: ReactOptions): void;
 export function getDefaults(): ReactOptions;
@@ -92,13 +92,11 @@ export type TFuncKey<N, T = Resources> = N extends (keyof T)[]
   ? Normalize<T[N]>
   : string;
 
-export type TFuncReturn<N, TKeys, TDefaultResult, T = Resources> = [keyof Resources] extends [never]
-  ? TDefaultResult
-  : N extends (keyof T)[]
+export type TFuncReturn<N, TKeys, TDefaultResult, T = Resources> = N extends (keyof T)[]
   ? NormalizeMultiReturn<T, TKeys>
   : N extends keyof T
   ? NormalizeReturn<T[N], TKeys>
-  : string;
+  : Fallback<TDefaultResult>;
 
 export interface TFunction<N extends Namespace = DefaultNamespace> {
   <
@@ -156,7 +154,7 @@ type UseTranslationResponse<N extends Namespace> = [TFunction<N>, i18n, boolean]
   ready: boolean;
 };
 
-type DefaultNamespace<T = 'translation'> = ResourcesKey extends T ? T : string;
+type DefaultNamespace<T = 'translation'> = Fallback<string> extends T ? T : string;
 
 export function useTranslation<N extends Namespace = DefaultNamespace>(
   ns?: N,

--- a/src/ts4.1/index.d.ts
+++ b/src/ts4.1/index.d.ts
@@ -12,7 +12,7 @@ import * as React from 'react';
 /**
  * Due to a limitation/bug on typescript 4.1 (https://github.com/microsoft/TypeScript/issues/41406), we added
  * "extends infer A ? A : never" in a few places to suppress the error "Type instantiation is excessively deep and possibly infinite."
- * on cases where users have more than 22 namespaces. Once the issue is fixed, we can remove all instances of workaround used.
+ * on cases where users have more than 22 namespaces. Once the issue is fixed, we can remove all instances of the workaround used.
  *
  * Reference of the bug reported: https://github.com/i18next/react-i18next/issues/1222
  */


### PR DESCRIPTION
Workaround for #1222

In this [link](https://www.typescriptlang.org/play?noUnusedLocals=true&ts=4.1.2#code/C4TwDgpgBAYghgGwQIzgYwNYB4YBooAqUAvFBhCAPYBmUAShAM6UCuATmkwHwlQDaBALpQIAD2AQAdgBNG-SRABuENsID8sKAC5CAbgBQ+gPRGoAOUpsAtogCWAL2iNbkgOYJokuFaZh0EfVBIKAB5K1tgAEE2NjgQAAU2SjBGLAIeUgBRUTQEFmkINPxyKlo4SRA+QS4DIOhIsEgZAGkKVOaARnxmgCYMqAADABIAb06oADIoRmA2F1cAXwA6UbCI6NiEpJSsXp4pmbm3BYHa8GgLaztHHqKoZt4SmkJ+h7EJGTkn2gJ9KCgNAQ+M1hO8pLJ6BA0JZpFhDvN8OUQFw-gCoA0mtJWiB2sUKM8gSCeAAfdGNcHY3HmSw2BAOCC3QnVFH-HQKZRsVFspQqM7BS60+lpfrfQhQUkC64M4UGYymSV0xxQKwsBDAWxgDxQLw+Rh+TiMQLnKAAVUktkokgIlAAkpIJGxGFD1ZasCb+gAKE0icTguRI1EaD0YHQmgCUJB4ikotmkXO1PLYEbBnygwZ0LmoKigNojxCjMbj-w0Nvj7N5RuCABk4DMQtRhbwzRarbb7SonWgXZIsKiiCmIUi0R68zwiNyOfoeAO5CPI1BM9m6IH6GXE3z6uSZGYAMpYMzdfrDEZmSbTWbzBZaUYPA4X46nSsXGlSgCyqvVd29M7I+J++CrXgazrBt3X6QCfxNFcMXBXcsCrfAFSFIEq2ZcVqSuRUIHfNVbDubJcnyQoTQArgWW0BMOVlOpzG8Xx-BwXh4CQVBMDhe9XDIpj0JgKpqONAgYBYSQ0GxfcfQ+CEzDovV-H6U8f2DP9IWYdgDTDKoVyQxwcM-BhVI4JhEL4SQWCsZAVGqeMFN9VNRX01hDMNYsMMFRwsActSmD4MwrNZSiKyfQghJE7txJ-aTdX1CB+l2CS-WC4TRIofdp1siFFzYdE0UiCjyzYLgPVREodGafRR3PI5XH44ITSdAhYkkRgEDgbt9LAS0nXC9K5Ei+jOH6EZUWAHRBKSsKzBqfQFllApcjgNhoGocaWygFh6sa5rWpbNJ4tTPrZIGj0mrUUaw1DDbyi2trfE6wp0llIwACooAAWnej7Pq+76ft+n79Be-4geBkG6o7KBoQKEHoZhqAnv0P7EaR5GPqeoxDBozynN4OpnkWgyDVlaEmuAKB8ccg1eCG-4mo6HRqaBkqoAZ4HGBYZBsR0AByeE3C51F-gWVEFlwVEmp6emBd-EBud51x+cF0WacYABmSXgaZnmOIVqARbFxgABZ1cZihZe14Wle1RgAFZjf+TW5Z1vXlYANjt6Wzaqp3LaagB2d2HfNxX9YADgD02oC1r2Lf1gBOcOZcjx2Y+VjoAAYE89+Zvf1jo6eZqXA+j4PU4lguNYjqPs5Tq2OjV8uTcTqu+Zr2nbYb+3K+Tkva7djuPaToPdZ9xgOn9-ui+rnvabDieu6H53a-juem+74f9Z6DOV6zlvp8YHp85Zgfm-l1v97Lo-J939flZ6evL-n4ub6tnoje3wen8X8X24f1eF5Hnofdf471PnvHo49gEfyns-cWs9IEnxzrfZe8C15f1VlvFB-9UTTSgLWCGnVgBEwIczKApMFi8HWhABqV0Wrdg9FzWmXMwwGGJjMMmTAPw43oSUJYbMOYUCYUQkmJCRqkJ6LrChl0mq0JbB6PgDDR5c0EMw-QrDSb4w-OI0gwAej0NploHhfDsSCP0EAA) you can see the fix.


#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [ ] documentation is changed or added