### PR TITLE
<Trans /> component breaks input values

### DIFF
--- a/test/trans.render.spec.js
+++ b/test/trans.render.spec.js
@@ -475,3 +475,20 @@ describe('trans should work with misleading overloaded empty elements in compone
     `);
   });
 });
+
+describe('trans should not interpret HTML-like structures in values', () => {
+  const TestComponent = () => (
+    <Trans
+      i18nKey="someKey"
+      defaults="A <strong>{{htmlElement}}</strong> B"
+      values={{ htmlElement: '<head>' }}
+    />
+  );
+
+  it('should render translated string', () => {
+    const { container } = render(<TestComponent />);
+    expect(container.innerHTML).toMatchInlineSnapshot(
+      `"<div>A <strong>&lt;head&gt;</strong> B</div>"`,
+    );
+  });
+});


### PR DESCRIPTION
# Why

Using `<Trans />` to render values that resemble HTML elements breaks
the values.

# What

This PR only adds a test case which reproduces the failure. It does
not fix the issue.

I took a quick look what the root cause is and whether there are
greater security implications (XSS possibilities). The cause seems
to be pretty straightforward. First, `Trans` executes the translation
via `t` and after the successful translation the `string` is
interpreted as HTML.

<img width="573" alt="Screenshot 2021-01-11 at 17 35 14" src="https://user-images.githubusercontent.com/596443/104212281-51f5df80-5435-11eb-9655-90d169658351.png">

To me it seems like the strategy should be the other way around –
especially to avoid security issues. Meaning: Parse the translation
string and only afterwards place the values.

Regarding potential security implications: I haven't fully analyzed this.
However, considering how complicated proper sanitization is (the
[DOMPurify](https://github.com/cure53/DOMPurify) project is a good indicator
just how hard this is), I believe this is something that should be verified as well.
