### PR TITLE
Fix compilation error in typescript examples

### DIFF
--- a/example/react-typescript4.1/namespaces/package.json
+++ b/example/react-typescript4.1/namespaces/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "@types/jest": "26.0.15",
     "@types/node": "12.0.0",
-    "@types/react": "16.9.53",
+    "@types/react": "17.0.1",
     "@types/react-dom": "16.9.8",
     "typescript": "4.1.2"
   },

--- a/example/react-typescript4.1/namespaces/yarn.lock
+++ b/example/react-typescript4.1/namespaces/yarn.lock
@@ -1744,10 +1744,10 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
-"@types/react@16.9.53":
-  version "16.9.53"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.53.tgz#40cd4f8b8d6b9528aedd1fff8fcffe7a112a3d23"
-  integrity sha512-4nW60Sd4L7+WMXH1D6jCdVftuW7j4Za6zdp6tJ33Rqv0nk1ZAmQKML9ZLD4H0dehA3FZxXR/GM8gXplf82oNGw==
+"@types/react@17.0.1":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.1.tgz#eb1f1407dea8da3bc741879c1192aa703ab9975b"
+  integrity sha512-w8t9f53B2ei4jeOqf/gxtc2Sswnc3LBK5s0DyJcg5xd10tMHXts2N31cKjWfH9IC/JvEPa/YF1U4YeP1t4R6HQ==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"

--- a/example/react-typescript4.1/no-namespaces/package.json
+++ b/example/react-typescript4.1/no-namespaces/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "@types/jest": "26.0.15",
     "@types/node": "12.0.0",
-    "@types/react": "16.9.53",
+    "@types/react": "17.0.1",
     "@types/react-dom": "16.9.8",
     "typescript": "4.1.2"
   },

--- a/example/react-typescript4.1/no-namespaces/yarn.lock
+++ b/example/react-typescript4.1/no-namespaces/yarn.lock
@@ -1744,10 +1744,10 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
-"@types/react@16.9.53":
-  version "16.9.53"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.53.tgz#40cd4f8b8d6b9528aedd1fff8fcffe7a112a3d23"
-  integrity sha512-4nW60Sd4L7+WMXH1D6jCdVftuW7j4Za6zdp6tJ33Rqv0nk1ZAmQKML9ZLD4H0dehA3FZxXR/GM8gXplf82oNGw==
+"@types/react@17.0.1":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.1.tgz#eb1f1407dea8da3bc741879c1192aa703ab9975b"
+  integrity sha512-w8t9f53B2ei4jeOqf/gxtc2Sswnc3LBK5s0DyJcg5xd10tMHXts2N31cKjWfH9IC/JvEPa/YF1U4YeP1t4R6HQ==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"


### PR DESCRIPTION
#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- n/a tests are included
- n/a documentation is changed or added

#### Compilation error

1. Check out the repo
2. Go to `example/react-typescript4.1/namespaces/` (and `no-namespaces`)
3. `yarn install`
4. `yarn start`

<img width="1726" alt="Screenshot 2021-02-06 at 21 22 56" src="https://user-images.githubusercontent.com/2437969/107128879-8c7e5b00-68c1-11eb-976a-12f644b9a906.png">

I updated the types to the version matching `react` dependency and it compiles properly now.