### PR TITLE
Add `transWrapTextNodes` option

### DIFF
--- a/src/Trans.js
+++ b/src/Trans.js
@@ -242,7 +242,12 @@ function renderNodes(children, targetString, i18n, i18nOptions, combinedTOpts) {
           mem.push(React.cloneElement(child, { ...child.props, key: i }));
         }
       } else if (node.type === 'text') {
-        mem.push(node.content);
+        const wrapTextNodes = i18nOptions.transWrapTextNodes;
+        if (wrapTextNodes) {
+          mem.push(React.createElement(wrapTextNodes, { key: `${node.name}-${i}` }, node.content));
+        } else {
+          mem.push(node.content);
+        }
       }
       return mem;
     }, []);

--- a/src/context.js
+++ b/src/context.js
@@ -6,6 +6,7 @@ let defaultOptions = {
   // nsMode: 'fallback' // loop through all namespaces given to hook, HOC, render prop for key lookup
   transEmptyNodeValue: '',
   transSupportBasicHtmlNodes: true,
+  transWrapTextNodes: '',
   transKeepBasicHtmlNodesFor: ['br', 'strong', 'i', 'p'],
   // hashTransKey: key => key // calculate a key for Trans component based on defaultValue
   useSuspense: true,
@@ -29,7 +30,7 @@ export class ReportNamespaces {
   }
 
   addUsedNamespaces(namespaces) {
-    namespaces.forEach(ns => {
+    namespaces.forEach((ns) => {
       if (!this.usedNamespaces[ns]) this.usedNamespaces[ns] = true;
     });
   }
@@ -57,12 +58,12 @@ export const initReactI18next = {
 };
 
 export function composeInitialProps(ForComponent) {
-  return ctx =>
-    new Promise(resolve => {
+  return (ctx) =>
+    new Promise((resolve) => {
       const i18nInitialProps = getInitialProps();
 
       if (ForComponent.getInitialProps) {
-        ForComponent.getInitialProps(ctx).then(componentsInitialProps => {
+        ForComponent.getInitialProps(ctx).then((componentsInitialProps) => {
           resolve({
             ...componentsInitialProps,
             ...i18nInitialProps,
@@ -94,9 +95,9 @@ export function getInitialProps() {
 
   const ret = {};
   const initialI18nStore = {};
-  i18n.languages.forEach(l => {
+  i18n.languages.forEach((l) => {
     initialI18nStore[l] = {};
-    namespaces.forEach(ns => {
+    namespaces.forEach((ns) => {
       initialI18nStore[l][ns] = i18n.getResourceBundle(l, ns) || {};
     });
   });

--- a/test/trans.render.spec.js
+++ b/test/trans.render.spec.js
@@ -546,3 +546,41 @@ describe('trans with null child', () => {
     `);
   });
 });
+
+describe('trans with wrapTextNodes', () => {
+  let orgValue;
+  beforeAll(() => {
+    orgValue = i18n.options.react.transWrapTextNodes;
+    i18n.options.react.transWrapTextNodes = 'span';
+  });
+  afterAll(() => {
+    i18n.options.react.transWrapTextNodes = orgValue;
+  })
+  
+  const TestComponent = () => (
+    <Trans i18nKey="transTest1">
+      Open <Link to="/msgs">here</Link>.
+    </Trans>
+  );
+
+  it('should wrap text nodes accordingly', () => {
+    const { container } = render(<TestComponent />);
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <div>
+        <span>
+          Go 
+        </span>
+        <a
+          href="/msgs"
+        >
+          <span>
+            there
+          </span>
+        </a>
+        <span>
+          .
+        </span>
+      </div>
+    `);
+  });
+});


### PR DESCRIPTION
The `transWrapTextNodes` option instructs react-i18next to wrap text nodes in a user-specified element. By default, text nodes are not wrapped.

Fixes: https://github.com/i18next/react-i18next/issues/1323

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [ ] documentation is changed or added