### PR TITLE
Allow for Custom DefaultNS typing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10871,9 +10871,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.9.9",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
-      "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
+      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "rollup-plugin-terser": "^5.1.1",
     "sinon": "^7.2.3",
     "tslint": "^5.13.1",
-    "typescript": "^3.6.4",
+    "typescript": "^4.3.2",
     "yargs": "13.3.0"
   },
   "peerDependencies": {
@@ -103,13 +103,14 @@
     "build": "npm run clean && npm run build:cjs && npm run build:es && npm run build:umd && npm run build:amd && npm run copy",
     "preversion": "npm run build && git push",
     "postversion": "git push && git push --tags",
-    "pretest": "npm run test:typescript && npm run test:typescript:noninterop",
+    "pretest": "npm run test:typescript && npm run test:typescript:noninterop && npm run test:typescript:customtypes",
     "test": "cross-env BABEL_ENV=development jest --no-cache",
     "test:watch": "cross-env BABEL_ENV=development jest --no-cache --watch",
     "test:coverage": "cross-env BABEL_ENV=development jest --no-cache --coverage",
     "test:lint": "eslint ./src ./test",
     "test:typescript": "tslint --project tsconfig.json",
     "test:typescript:noninterop": "tslint --project tsconfig.nonEsModuleInterop.json",
+    "test:typescript:customtypes": "tslint --project ./test/typescript/custom-types/tsconfig.json",
     "contributors:add": "all-contributors add",
     "contributors:generate": "all-contributors generate",
     "prettier": "prettier --write \"{,**/}*.{ts,tsx,js,json,md}\""

--- a/package.json
+++ b/package.json
@@ -126,6 +126,9 @@
     "testMatch": [
       "**/test/?(*.)(spec|test).js?(x)"
     ],
+    "modulePathIgnorePatterns": [
+      "<rootDir>/example/"
+    ],
     "collectCoverageFrom": [
       "**/src/*.{js,jsx}",
       "*.macro.js",

--- a/test/typescript/custom-types/Trans.test.tsx
+++ b/test/typescript/custom-types/Trans.test.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { Trans } from 'react-i18next';
+
+function defaultNamespaceUsage() {
+  return <Trans i18nKey="foo">foo</Trans>;
+}
+
+function namedDefaultNamespaceUsage() {
+  return (
+    <Trans ns="custom" i18nKey="foo">
+      foo
+    </Trans>
+  );
+}
+
+function alternateNamespaceUsage() {
+  return (
+    <Trans ns="alternate" i18nKey="baz">
+      foo
+    </Trans>
+  );
+}
+
+function arrayNamespace() {
+  return (
+    <Trans ns={['alternate', 'custom']} i18nKey={['alternate:baz', 'custom:bar']}>
+      foo
+    </Trans>
+  );
+}
+
+function expectErrorWhenNamespaceDoesNotExist() {
+  return (
+    // @ts-expect-error
+    <Trans ns="fake" i18nKey="foo">
+      foo
+    </Trans>
+  );
+}
+
+function expectErrorWhenKeyNotInNamespace() {
+  return (
+    // @ts-expect-error
+    <Trans ns="custom" i18nKey="fake">
+      foo
+    </Trans>
+  );
+}
+
+function expectErrorWhenUsingArrayNamespaceAndUnscopedKey() {
+  return (
+    // @ts-expect-error
+    <Trans ns={['custom']} i18nKey={['foo']}>
+      foo
+    </Trans>
+  );
+}
+
+function expectErrorWhenUsingArrayNamespaceAndWrongKey() {
+  return (
+    // @ts-expect-error
+    <Trans ns={['custom']} i18nKey={['custom:fake']}>
+      foo
+    </Trans>
+  );
+}

--- a/test/typescript/custom-types/Translation.test.tsx
+++ b/test/typescript/custom-types/Translation.test.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { Translation } from 'react-i18next';
+
+function defaultNamespaceUsage() {
+  return <Translation>{(t) => <>{t('foo')}</>}</Translation>;
+}
+
+function namedDefaultNamespaceUsage() {
+  return <Translation ns="custom">{(t) => <>{t('foo')}</>}</Translation>;
+}
+
+function alternateNamespaceUsage() {
+  return <Translation ns="alternate">{(t) => <>{t('baz')}</>}</Translation>;
+}
+
+function arrayNamespace() {
+  return (
+    <Translation ns={['alternate', 'custom']}>
+      {(t) => (
+        <>
+          {t('alternate:baz')}
+          {t('custom:foo')}
+        </>
+      )}
+    </Translation>
+  );
+}
+
+function expectErrorWhenNamespaceDoesNotExist() {
+  // @ts-expect-error
+  return <Translation ns="fake">{(t) => <>{t('foo')}</>}</Translation>;
+}
+
+function expectErrorWhenKeyNotInNamespace() {
+  // @ts-expect-error
+  return <Translation ns="custom">{(t) => <>{t('fake')}</>}</Translation>;
+}
+
+function expectErrorWhenUsingArrayNamespaceAndUnscopedKey() {
+  // @ts-expect-error
+  return <Translation ns={['custom']}>{(t) => <>{t('foo')}</>}</Translation>;
+}
+
+function expectErrorWhenUsingArrayNamespaceAndWrongKey() {
+  // @ts-expect-error
+  return <Translation ns={['custom']}>{(t) => <>{t('custom:fake')}</>}</Translation>;
+}

--- a/test/typescript/custom-types/custom-types.d.ts
+++ b/test/typescript/custom-types/custom-types.d.ts
@@ -1,0 +1,16 @@
+import 'react-i18next';
+
+declare module 'react-i18next' {
+  interface CustomTypeOptions {
+    defaultNS: 'custom';
+    resources: {
+      custom: {
+        foo: 'foo';
+        bar: 'bar';
+      };
+      alternate: {
+        baz: 'baz';
+      };
+    };
+  }
+}

--- a/test/typescript/custom-types/tsconfig.json
+++ b/test/typescript/custom-types/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["./**/*"],
+  "exclude": []
+}

--- a/test/typescript/custom-types/useTranslation.test.tsx
+++ b/test/typescript/custom-types/useTranslation.test.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+
+function defaultNamespaceUsage() {
+  const { t } = useTranslation();
+
+  return <>{t('foo')}</>;
+}
+
+function namedDefaultNamespaceUsage() {
+  const [t] = useTranslation('custom');
+  return <>{t('bar')}</>;
+}
+
+function alternateNamespaceUsage() {
+  const [t] = useTranslation('alternate');
+  return <>{t('baz')}</>;
+}
+
+function arrayNamespace() {
+  const [t] = useTranslation(['alternate', 'custom']);
+  return (
+    <>
+      {t('alternate:baz')}
+      {t('custom:foo')}
+    </>
+  );
+}
+
+function expectErrorWhenNamespaceDoesNotExist() {
+  // @ts-expect-error
+  const [t] = useTranslation('fake');
+  return <>{t('foo')}</>;
+}
+
+function expectErrorWhenKeyNotInNamespace() {
+  const [t] = useTranslation('custom');
+  // @ts-expect-error
+  return <>{t('fake')}</>;
+}
+
+function expectErrorWhenUsingArrayNamespaceAndUnscopedKey() {
+  const [t] = useTranslation(['custom']);
+  // @ts-expect-error
+  return <>{t('foo')}</>;
+}
+
+function expectErrorWhenUsingArrayNamespaceAndWrongKey() {
+  const [t] = useTranslation(['custom']);
+  // @ts-expect-error
+  return <>{t('custom:fake')}</>;
+}

--- a/test/typescript/withTranslation.test.tsx
+++ b/test/typescript/withTranslation.test.tsx
@@ -3,7 +3,7 @@ import { withTranslation, WithTranslation } from 'react-i18next';
 import { default as myI18n } from './i18n';
 
 /**
- * @see https://react.i18next.com/latest/trans-component
+ * see https://react.i18next.com/latest/trans-component
  */
 
 interface MyComponentProps extends WithTranslation {
@@ -34,7 +34,7 @@ function defaultUsageWithDefaultProps() {
 }
 
 /**
- * @see https://react.i18next.com/latest/withtranslation-hoc#withtranslation-params
+ * see https://react.i18next.com/latest/withtranslation-hoc#withtranslation-params
  */
 function withNs() {
   const ExtendedComponent = withTranslation('ns')(MyComponent);
@@ -47,7 +47,7 @@ function withNsArray() {
 }
 
 /**
- * @see https://react.i18next.com/latest/withtranslation-hoc#overriding-the-i-18-next-instance
+ * see https://react.i18next.com/latest/withtranslation-hoc#overriding-the-i-18-next-instance
  */
 function withI18nOverride() {
   const ExtendedComponent = withTranslation('ns')(MyComponent);
@@ -55,7 +55,7 @@ function withI18nOverride() {
 }
 
 /**
- * @see https://react.i18next.com/latest/withtranslation-hoc#not-using-suspense
+ * see https://react.i18next.com/latest/withtranslation-hoc#not-using-suspense
  */
 function withSuspense() {
   const ExtendedComponent = withTranslation('ns')(MyComponent);

--- a/ts4.1/index.d.ts
+++ b/ts4.1/index.d.ts
@@ -21,6 +21,8 @@ type Subtract<T extends K, K> = Omit<T, keyof K>;
 
 /**
  * This interface can be augmented by users to add types to `react-i18next` default resources.
+ *
+ * @deprecated use the `resources` key of `CustomTypeOptions` instead
  */
 export interface Resources {}
 /**

--- a/ts4.1/index.d.ts
+++ b/ts4.1/index.d.ts
@@ -25,6 +25,10 @@ type Subtract<T extends K, K> = Omit<T, keyof K>;
 export interface Resources {}
 /**
  * This interface can be augmented by users in case they define a custom `defaultNS`.
+ *
+ * ```ts
+ * interface DefaultNS { name: 'myCustomNamespace' }
+ * ```
  */
 export interface DefaultNS {}
 

--- a/ts4.1/index.d.ts
+++ b/ts4.1/index.d.ts
@@ -23,6 +23,10 @@ type Subtract<T extends K, K> = Omit<T, keyof K>;
  * This interface can be augmented by users to add types to `react-i18next` default resources.
  */
 export interface Resources {}
+/**
+ * This interface can be augmented by users in case they define a custom `defaultNS`.
+ */
+export interface DefaultNS {}
 
 type Fallback<F, T = keyof Resources> = [T] extends [never] ? F : T;
 
@@ -158,7 +162,12 @@ type UseTranslationResponse<N extends Namespace> = [TFunction<N>, i18n, boolean]
   ready: boolean;
 };
 
-type DefaultNamespace<T = 'translation'> = T extends Fallback<string> ? T : string;
+type TranslationNS = 'translation';
+type NameKey = 'name';
+
+type ExtractName<T> = T extends { [key in NameKey]: unknown } ? T[NameKey] : TranslationNS;
+
+type DefaultNamespace<T = ExtractName<DefaultNS>> = T extends Fallback<string> ? T : string;
 
 export function useTranslation<N extends Namespace = DefaultNamespace>(
   ns?: N,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "allowSyntheticDefaultImports": true
   },
   "include": ["./src/**/*", "./test/**/*"],
-  "exclude": ["test/typescript/nonEsModuleInterop/**/*.ts"]
+  "exclude": ["test/typescript/nonEsModuleInterop/**/*.ts", "test/typescript/custom-types"]
 }


### PR DESCRIPTION
## Description

This PR allows the declaration of custom `defaultNS` types and should fix #1302 
It also implements a new way of typing the `Resources` by using the `resources` key inside `CustomTypeOptions` instead of the previous API, `Resources` has been marked as deprecated as well

## Usage

```ts
// i18n.ts
i18n.use(initReactI18next).init({
  defaultNS: 'ns1'
  ...
});

// react-i18next.d.ts
declare module 'react-i18next' {
  interface CustomTypeOptions {
    defaultNS: 'ns1';
    resources: {
      ns1: typeof ns1;
      ns2: typeof ns2;
    };
  }
}
```

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [ ] documentation is changed or added