### PR TITLE
Make typescript autocomplete aware of contextSeparator

### DIFF
--- a/test/typescript/custom-types/custom-types.d.ts
+++ b/test/typescript/custom-types/custom-types.d.ts
@@ -11,6 +11,17 @@ declare module 'react-i18next' {
       alternate: {
         baz: 'baz';
       };
+      withContext: {
+        type_male: 'Man';
+        type_female: 'Woman';
+        person: 'Person';
+        person_plural: 'Persons';
+        key_with_multiple: 'Multiple';
+        animal: {
+          type_lion: 'Lion';
+          type_penguin: 'Penguin';
+        };
+      };
     };
   }
 }

--- a/test/typescript/custom-types/useTranslation.test.tsx
+++ b/test/typescript/custom-types/useTranslation.test.tsx
@@ -50,3 +50,37 @@ function expectErrorWhenUsingArrayNamespaceAndWrongKey() {
   // @ts-expect-error
   return <>{t('custom:fake')}</>;
 }
+
+// Test Context
+
+function fullKeyUsage() {
+  const { t } = useTranslation('withContext');
+  return t('animal.type_lion');
+}
+
+function arrayFullKeyUsage() {
+  const [t] = useTranslation(['withContext']);
+  return t('withContext:animal.type_lion');
+}
+
+function withoutContext() {
+  const { t } = useTranslation('withContext');
+  const result = t('animal.type');
+  return result === 'Lion' || result === 'Penguin';
+}
+
+function contextUsage() {
+  const { t } = useTranslation('withContext');
+  return t('animal.type', { context: 'lion' }) === 'Lion';
+}
+
+function keyWithMultipleUnderscores() {
+  const { t } = useTranslation('withContext');
+  return t('key_with') === 'Multiple';
+}
+
+function pluralUsage() {
+  const { t } = useTranslation('withContext');
+  const result = t('person', { count: 1 });
+  return result === 'Persons' || result === 'Person';
+}

--- a/test/typescript/custom-types/useTranslation.test.tsx
+++ b/test/typescript/custom-types/useTranslation.test.tsx
@@ -55,12 +55,22 @@ function expectErrorWhenUsingArrayNamespaceAndWrongKey() {
 
 function fullKeyUsage() {
   const { t } = useTranslation('withContext');
-  return t('animal.type_lion');
+  t('animal.type');
+  t('animal.type_lion');
+  t('animal.type_penguin');
 }
 
 function arrayFullKeyUsage() {
   const [t] = useTranslation(['withContext']);
-  return t('withContext:animal.type_lion');
+  t('withContext:animal.type');
+  t('withContext:animal.type_lion');
+  t('withContext:animal.type_penguin');
+}
+
+function expectErrorWhenKeyInvalid() {
+  const { t } = useTranslation('withContext');
+  // @ts-expect-error
+  t('animal.type_car');
 }
 
 function withoutContext() {


### PR DESCRIPTION
This makes the `react-i18next` types aware of the `contextSeparator`, we might want to make it possible to change it later, similar to how we allow changing the `defaultNS`, but for now it should be simple to fix and user's issue.

How it works: keys that end in `_${string}` will be added with and without the ending to the type auto-completion.

eg:

```ts
const resources = {
  translation: {
    type_male: "Male",
    type_female: "Female",
  }
}

t('type') // valid
t('type_male') // valid
t('type_female') // valid
t('type_missing') // invalid
```

fixes #1333 

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [ ] documentation is changed or added