### PR TITLE
feat(types): allow readonly namespaces in useTranslation

### DIFF
--- a/test/typescript/custom-types/useTranslation.test.tsx
+++ b/test/typescript/custom-types/useTranslation.test.tsx
@@ -27,6 +27,17 @@ function arrayNamespace() {
   );
 }
 
+function readonlyArrayNamespace() {
+  const namespaces = ['alternate', 'custom'] as const;
+  const [t] = useTranslation(namespaces);
+  return (
+    <>
+      {t('alternate:baz')}
+      {t('custom:foo')}
+    </>
+  );
+}
+
 function expectErrorWhenNamespaceDoesNotExist() {
   // @ts-expect-error
   const [t] = useTranslation('fake');

--- a/ts4.1/index.d.ts
+++ b/ts4.1/index.d.ts
@@ -197,7 +197,7 @@ type UseTranslationResponse<N extends Namespace> = [TFunction<N>, i18n, boolean]
 };
 
 export function useTranslation<N extends Namespace = DefaultNamespace>(
-  ns?: N,
+  ns?: N | Readonly<N>,
   options?: UseTranslationOptions,
 ): UseTranslationResponse<N>;
 


### PR DESCRIPTION
`useTranslation()` typings signature changed to allow a readonly version of namespaces argument... 

## Code

```typescript
// From a readonly configuration. the const here is used
//  - to guarantee immutability (type level)
//  - helps typescript to narrow the type
//
export const nsConfig = ['ns1', 'ns2'] as const; 

// An example component
export const Test: React.FC = () => {
   const { t } = useTranslation(nsConfig);
   return <></>
}
```

Prior to this P/R, typecheck in strict mode would complain about

```
TS2345: Argument of type 'readonly ["common", "demo"]' is not assignable to parameter of type 'Namespace<"common" | "demo" | "home"> | undefined'.   The type 'readonly ["common", "demo"]' is 'readonly' and cannot be assigned to the mutable type '("common" | "demo" | "home")[]'.
```

## Alternative hack:

It's possible to remove the readonly from readonly config, lacks elegance

```ts
export const nsConfig = ['ns1', 'ns2'] as const; // the `const` modifier will
type Writeable<T> = { -readonly [P in keyof T]: T[P] };
export const Test: React.FC = () => {
   const { t } = useTranslation(nsConfig as Writeable<typeof nsConfig>);
   return <></>
}
```


#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [ ] documentation is changed or added

