### PR TITLE
feat(typings): support readonly namespaces in TFuncKey

### DIFF
--- a/ts4.1/index.d.ts
+++ b/ts4.1/index.d.ts
@@ -125,10 +125,9 @@ type NormalizeMultiReturn<T, V> = V extends `${infer N}:${infer R}`
     : never
   : never;
 
-export type TFuncKey<
-  N extends Namespace = DefaultNamespace,
-  T = DefaultResources
-> = N extends (keyof T)[]
+export type TFuncKey<N extends Namespace = DefaultNamespace, T = DefaultResources> = N extends
+  | (keyof T)[]
+  | Readonly<(keyof T)[]>
   ? NormalizeMulti<T, N[number]>
   : N extends keyof T
   ? Normalize<T[N]>


### PR DESCRIPTION
Follow up of 

- feat(types): allow readonly namespaces in useTranslation, see https://github.com/i18next/react-i18next/pull/1339

While the initial P/R allows to readonly namespace array... the `t` function choose to fallback to all configured namespaces (ie: 'common', 'home', 'other-context')... defeating perfect typechecks

```tsx
export const nsPageConfig = ['common', 'home'] as const; 
export const Page = () => {
  // 1. Ok it works thx https://github.com/i18next/react-i18next/pull/1339
  const { t } = useTranslation(nsPageConfig);
  return (
    <div>
       // 2. Ok it works, the typecheck occurs 
       <span>{t('home:thekeyexists')}</span>
       // 3. Oups, it allows 'other-context', but it's not in the nsPageconfig
       <span>{t('other-context:thekeyexists')}</span>
    </div>
  );
}
```

With this P/R it will work well.

But, I'd like to have a second reading on this... cause in my guts I feel that changing the signature of TFuncKey would see a theoretical drop of performance... 

I need to check it out on a larger project or maybe a typescript guru would find a better way ?

An option that I'm investigating also is to remove readonly from useTranslation return, I don't know how to it... Something in the lines of 

```typescript
export function useTranslation<N extends Namespace = DefaultNamespace>(
  ns?: N | Readonly<N>,
  options?: UseTranslationOptions,
  // Here trying out to remove the readonly modifier on the array
  // That would allow to not change the TFuncKey signature
): UseTranslationResponse<MAKEMUTABLEIFREADONLY<N>>;
```

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [ ] documentation is changed or added