### PR TITLE
feat(types): add returnNull and returnEptyString options to TypeOptions interface

### DIFF
--- a/test/typescript/returnTypes.test.ts
+++ b/test/typescript/returnTypes.test.ts
@@ -1,0 +1,33 @@
+import { NormalizeByTypeOptions } from 'react-i18next';
+
+// Test cases for TypeOptions['returnNull']: true
+type ReturnNull = NormalizeByTypeOptions<null, { returnNull: true }>; // Returns null
+
+const nullableValue: ReturnNull = null;
+
+// @ts-expect-error: null is not assignable to string
+const nonNullableValue: ReturnNull = '';
+
+// Test cases for TypeOptions['returnNull']: false
+type ReturnNonNullable = NormalizeByTypeOptions<null, { returnNull: false }>; // Returns string
+
+// @ts-expect-error: null is not assignable to string
+const nullableValue2: ReturnNonNullable = null;
+
+const nonNullableValue2: ReturnNonNullable = '';
+
+// Test cases for TypeOptions['returnEmptyString']: false
+type ReturnNonEmptyString = NormalizeByTypeOptions<'', { returnEmptyString: false }>; // Returns string
+
+const emptyStringValue: ReturnNonEmptyString = '';
+
+// Emtpy string should always be assignable to string, but not viceversa
+const nonEmptyStringValue: ReturnNonEmptyString = 'non-empty-string';
+
+// Test cases for TypeOptions['returnEmptyString']: true
+type ReturnEmptyString = NormalizeByTypeOptions<'', { returnEmptyString: true }>; // Returns ""
+
+const emptyStringValue2: ReturnEmptyString = '';
+
+// @ts-expect-error: '"non-empty-string"' is not assignable to type '""'
+const nonEmptyStringValue2: ReturnEmptyString = 'non-empty-string';


### PR DESCRIPTION
Working with react-i18next and typescript, I found that **returnNull** and **returnEptyString** [options](https://www.i18next.com/overview/configuration-options#translation-defaults) were not represented in typescript signatures.

By providing keys for these values inside the `CustomTypeOptions`, we can refine the return types for TFunction. 

```tsx
const dictionary = {
    ...
    nullValue: null,
    emptyString: "",
}

t('nullValue') // By default, signature returns null.
t('emptyString') // By default, signature returns ""
```

```tsx
declare module 'react-i18next' {
    interface CustomTypeOptions extends MyCustomTypeOptions {
        returnNull: false,
        returnEmptyString: false,
    }
}

t('nullValue') // After moduleAugmentation, signature returns string, representing the key.
t('emptyString') // After moduleAugmentation, signature returns string, representing the key.
```

Notice that these keys must be aligned with the actual options in the i18next instance in order to represent the actual behaviour of the library on runtime. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [ ] documentation is changed or added