### PR TITLE
feat(types): allow key separator augmentation

### DIFF
--- a/test/typescript/returnTypes.test.ts
+++ b/test/typescript/returnTypes.test.ts
@@ -1,4 +1,4 @@
-import { NormalizeByTypeOptions } from 'react-i18next';
+import { AppendKeys, NormalizeByTypeOptions, NormalizeReturn, TFuncReturn } from 'react-i18next';
 
 // Test cases for TypeOptions['returnNull']: true
 type ReturnNull = NormalizeByTypeOptions<null, { returnNull: true }>; // Returns null
@@ -31,3 +31,32 @@ const emptyStringValue2: ReturnEmptyString = '';
 
 // @ts-expect-error: '"non-empty-string"' is not assignable to type '""'
 const nonEmptyStringValue2: ReturnEmptyString = 'non-empty-string';
+
+// Test cases for TypeOptions['keySeparator']: '.' (default)
+type DefaultCase = AppendKeys<'namespace', 'key' | 'key2'>;
+const defaultCaseExpectedResult = 'namespace.key';
+const defaultCaseExpectedResult2 = 'namespace.key2';
+const defaultCase: DefaultCase = defaultCaseExpectedResult;
+const defaultCase2: DefaultCase = defaultCaseExpectedResult2;
+
+// Test cases for TypeOptions['keySeparator']: '>>>' (arbitrary separator)
+type ArbitrarySeparatorCase = AppendKeys<'namespace', 'key' | 'key2', '>>>'>;
+const arbitrarySeparatorExpectedResult = 'namespace>>>key';
+const arbitrarySeparatorExpectedResult2 = 'namespace>>>key2';
+const arbitrarySeparatorCase: ArbitrarySeparatorCase = arbitrarySeparatorExpectedResult;
+const arbitrarySeparatorCase2: ArbitrarySeparatorCase = arbitrarySeparatorExpectedResult2;
+
+// Test cases for TypeOptions['keySeparator']: false (nesting not supported)
+interface MockDictionary { key: { nested: 'value' }; notNested: 'value' };
+
+type ReturnGivenKey = NormalizeReturn<MockDictionary, 'key.nested', false>;
+const shouldBeGivenKey: ReturnGivenKey = 'key.nested';
+
+type ReturnGivenKey2 = NormalizeReturn<MockDictionary, 'keyfalsenested', false>;
+const shouldBeGivenKey2: ReturnGivenKey2 = 'keyfalsenested';
+
+type ReturnValue = NormalizeReturn<MockDictionary, 'notNested', false>;
+const shouldBeTranslationValue: ReturnValue = 'value';
+
+type ReturnValue2 = NormalizeReturn<MockDictionary, 'key//nested', '//'>;
+const shouldBeTranslationValue2: ReturnValue2 = 'value';

--- a/ts4.1/index.d.ts
+++ b/ts4.1/index.d.ts
@@ -54,6 +54,7 @@ type TypeOptions = MergeBy<
   {
     returnNull: true;
     returnEmptyString: true;
+    keySeparator: '.';
     defaultNS: 'translation';
     resources: Resources;
   },
@@ -92,8 +93,10 @@ declare module 'i18next' {
 }
 
 // Normalize single namespace
-type AppendKeys<K1, K2> = `${K1 & string}.${K2 & string}`;
-type AppendKeys2<K1, K2> = `${K1 & string}.${Exclude<K2, keyof any[]> & string}`;
+type AppendKeys<K1, K2, S extends string = TypeOptions['keySeparator']> = `${K1 & string}${S}${K2 &
+  string}`;
+type AppendKeys2<K1, K2, S extends string = TypeOptions['keySeparator']> = `${K1 &
+  string}${S}${Exclude<K2, keyof any[]> & string}`;
 type Normalize2<T, K = keyof T> = K extends keyof T
   ? T[K] extends Record<string, any>
     ? T[K] extends readonly any[]
@@ -135,12 +138,18 @@ export type NormalizeByTypeOptions<
   R = TypeOptionsFallback<TranslationValue, Options['returnEmptyString'], ''>
 > = TypeOptionsFallback<R, Options['returnNull'], null>;
 
-type NormalizeReturn<T, V> = V extends `${infer K}.${infer R}`
+type NormalizeReturn<
+  T,
+  V,
+  S extends string | false = TypeOptions['keySeparator']
+> = V extends keyof T
+  ? NormalizeByTypeOptions<T[V]>
+  : S extends false
+  ? V
+  : V extends `${infer K}${S}${infer R}`
   ? K extends keyof T
     ? NormalizeReturn<T[K], R>
     : never
-  : V extends keyof T
-  ? NormalizeByTypeOptions<T[V]>
   : never;
 
 type NormalizeMultiReturn<T, V> = V extends `${infer N}:${infer R}`


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

ATM, type checking the dictionaries will not work properly if you have changed the keySeparator for javascript:

```ts
i18n.init({
  ...
  keySeparator: '>>>',
)}:

t('key>>>nested') // Will translate at runtime, but typescript will complain, as he is always expecting the default key separator. 

```
The changes that im proposing allows to augment the keySeparator, in order to maintain aligned the typescript interface and the i18n instance.

Nevertheless, im not happy with all the code changes cause i had to rewrite `NormalizeReturn`, and it became too complex to really understand all the chaining conditions, so if you have any clue of how it should remain simple, please let me know.

Thank you in advance for reviewing this changes.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided