### PR TITLE
Fix preact issue with Trans when both children and components are undefined

### DIFF
--- a/src/Trans.js
+++ b/src/Trans.js
@@ -258,7 +258,11 @@ function renderNodes(children, targetString, i18n, i18nOptions, combinedTOpts) {
   // call mapAST with having react nodes nested into additional node like
   // we did for the string ast from translation
   // return the children of that extra node to get expected result
-  const result = mapAST([{ dummy: true, children }], ast, getAsArray(children || []));
+  const result = mapAST(
+    [{ dummy: true, children: children || [] }],
+    ast,
+    getAsArray(children || []),
+  );
   return getChildren(result[0]);
 }
 

--- a/test/trans.render.spec.js
+++ b/test/trans.render.spec.js
@@ -428,6 +428,23 @@ describe('trans with only content from translation file - no children', () => {
   });
 });
 
+describe('trans with only html content from translation file - no children', () => {
+  const TestComponent = () => <Trans i18nKey="transTest1_customHtml2" />;
+  it('should render translated string', () => {
+    const { container } = render(<TestComponent />);
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <div>
+        <strong>
+          Go
+        </strong>
+         
+        <br />
+         there.
+      </div>
+    `);
+  });
+});
+
 describe('trans should not break on invalid node from translations', () => {
   const TestComponent = () => <Trans i18nKey="testInvalidHtml" />;
   it('should render translated string', () => {


### PR DESCRIPTION
### Description

I stumbled upon a bug when integrating `react-i18next` in an app that uses preact. It turns out that if you use `Trans` component with no `children` and you do not pass any `components`, the whole translation will not render. It works with React, but not with Preact. Here are simple reproductions:

- React: https://codesandbox.io/s/react-3txsi
- Preact (no `children` and no `components`): https://codesandbox.io/s/preact-trans-no-children-no-components-unwxw
- Preact (no `children`, empty object passed to `components`): https://codesandbox.io/s/preact-trans-no-children-empty-object-components-wnrmq



#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included

