### PR TITLE
feature: add key prefix support to useTranslation hook

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -52,6 +52,7 @@ export function useSSR(initialI18nStore: Resource, initialLanguage: string): voi
 export interface UseTranslationOptions {
   i18n?: i18n;
   useSuspense?: boolean;
+  keyPrefix?: string;
 }
 export type UseTranslationResponse = [TFunction, i18n, boolean] & {
   t: TFunction;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6188,9 +6188,9 @@
       }
     },
     "i18next": {
-      "version": "20.3.1",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-20.3.1.tgz",
-      "integrity": "sha512-WTY07KreR5z2LBSzAIKs05zpR5tgUT98C4fD96e7Risbc/HZePwF6AEnb9VkjdeSeRn9PDqQBay7ZkphuXt0Xw==",
+      "version": "20.6.1",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-20.6.1.tgz",
+      "integrity": "sha512-yCMYTMEJ9ihCwEQQ3phLo7I/Pwycf8uAx+sRHwwk5U9Aui/IZYgQRyMqXafQOw5QQ7DM1Z+WyEXWIqSuJHhG2A==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.0"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint-plugin-react": "^7.16.0",
     "eslint-plugin-testing-library": "^3.10.1",
     "husky": "^3.0.3",
-    "i18next": "^20.0.0",
+    "i18next": "^20.6.0",
     "jest": "^24.8.0",
     "jest-cli": "^24.8.4",
     "lint-staged": "^8.1.3",

--- a/src/useTranslation.js
+++ b/src/useTranslation.js
@@ -24,7 +24,7 @@ export function useTranslation(ns, props = {}) {
     );
 
   const i18nOptions = { ...getDefaults(), ...i18n.options.react, ...props };
-  const { useSuspense } = i18nOptions;
+  const { useSuspense, keyPrefix } = i18nOptions;
 
   // prepare having a namespace
   let namespaces = ns || defaultNSFromContext || (i18n.options && i18n.options.defaultNS);
@@ -40,7 +40,11 @@ export function useTranslation(ns, props = {}) {
 
   // binding t function to namespace (acts also as rerender trigger)
   function getT() {
-    return i18n.getFixedT(null, i18nOptions.nsMode === 'fallback' ? namespaces : namespaces[0]);
+    return i18n.getFixedT(
+      null,
+      i18nOptions.nsMode === 'fallback' ? namespaces : namespaces[0],
+      keyPrefix,
+    );
   }
   const [t, setT] = useState(getT);
 

--- a/test/useTranslation.spec.js
+++ b/test/useTranslation.spec.js
@@ -114,6 +114,19 @@ describe('useTranslation', () => {
     });
   });
 
+  describe('key prefix', () => {
+    i18nInstance.addResource('en', 'translation', 'deeply.nested.key', 'here!');
+
+    it('should apply keyPrefix', () => {
+      const { result } = renderHook(() =>
+        useTranslation('translation', { i18n: i18nInstance, keyPrefix: 'deeply.nested' }),
+      );
+      const { t } = result.current;
+      expect(t('key')).toBe('here!');
+      expect(t.keyPrefix).toBe('deeply.nested');
+    });
+  });
+
   describe('replacing i18n instance in provider', () => {
     i18nInstance.addResource('fr', 'translation', 'key1', 'test2');
     const i18nInstanceClone = i18nInstance.cloneInstance({ lng: 'fr' });

--- a/ts4.1/index.d.ts
+++ b/ts4.1/index.d.ts
@@ -211,6 +211,7 @@ export function useSSR(initialI18nStore: Resource, initialLanguage: string): voi
 export interface UseTranslationOptions {
   i18n?: i18n;
   useSuspense?: boolean;
+  keyPrefix?: string;
 }
 
 type UseTranslationResponse<N extends Namespace> = [TFunction<N>, i18n, boolean] & {


### PR DESCRIPTION
Add `keyPrefix` option for `useTranslation` hook (Issue #1359)

```
i18next.addResource('en', 'translation', 'very.deeply.nested.key', 'here!');
const { t } = useTranslation('translation', { i18n: i18next, keyPrefix: 'very.deeply.nested' });
const text = t('key'); // "here"
```

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided

### Scope of changes:
- Added `keyPrefix` param handling for `useTranslation` hook
- Added test for checking the param
- Added TS typing
- Updated `i18next` dep to `2.6.0` (`keyPrefix` param added to `getFixedT`)