### PR TITLE
Add type-safe support to deep keyPrefix

### DIFF
--- a/test/typescript/custom-types/Trans.test.tsx
+++ b/test/typescript/custom-types/Trans.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Trans } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 function defaultNamespaceUsage() {
   return <Trans i18nKey="foo">foo</Trans>;
@@ -24,6 +24,26 @@ function alternateNamespaceUsage() {
 function arrayNamespace() {
   return (
     <Trans ns={['alternate', 'custom']} i18nKey={['alternate:baz', 'custom:bar']}>
+      foo
+    </Trans>
+  );
+}
+
+function withTfunction() {
+  const { t } = useTranslation('alternate');
+
+  return (
+    <Trans t={t} i18nKey="foobar.barfoo">
+      foo
+    </Trans>
+  );
+}
+
+function withTfunctionAndKeyPrefix() {
+  const { t } = useTranslation('alternate', { keyPrefix: 'foobar.deep' });
+
+  return (
+    <Trans t={t} i18nKey="deeper.deeeeeper">
       foo
     </Trans>
   );
@@ -60,6 +80,17 @@ function expectErrorWhenUsingArrayNamespaceAndWrongKey() {
   return (
     // @ts-expect-error
     <Trans ns={['custom']} i18nKey={['custom:fake']}>
+      foo
+    </Trans>
+  );
+}
+
+function withTfunctionAndKeyPrefixAndWrongKey() {
+  const { t } = useTranslation('alternate', { keyPrefix: 'foobar.deep' });
+
+  return (
+    // @ts-expect-error
+    <Trans t={t} i18nKey="xxx">
       foo
     </Trans>
   );

--- a/test/typescript/custom-types/custom-types.d.ts
+++ b/test/typescript/custom-types/custom-types.d.ts
@@ -12,6 +12,11 @@ declare module 'react-i18next' {
         baz: 'baz';
         foobar: {
           barfoo: 'barfoo';
+          deep: {
+            deeper: {
+              deeeeeper: 'foobar';
+            };
+          };
         };
       };
       plurals: {

--- a/test/typescript/custom-types/useTranslation.test.tsx
+++ b/test/typescript/custom-types/useTranslation.test.tsx
@@ -43,6 +43,16 @@ function keyPrefixOption() {
   return <>{t('barfoo')}</>;
 }
 
+function deepKeyPrefixOption() {
+  const [t] = useTranslation('alternate', { keyPrefix: 'foobar.deep' });
+  return (
+    <>
+      {t('deeper').deeeeeper}
+      {t('deeper.deeeeeper')}
+    </>
+  );
+}
+
 function jsonFormatV4Plurals() {
   const [t] = useTranslation('plurals');
   return (

--- a/test/typescript/returnTypes.test.ts
+++ b/test/typescript/returnTypes.test.ts
@@ -1,4 +1,4 @@
-import { AppendKeys, NormalizeByTypeOptions, NormalizeReturn, TFuncReturn } from 'react-i18next';
+import { KeysWithSeparator, NormalizeByTypeOptions, NormalizeReturn } from 'react-i18next';
 
 // Test cases for TypeOptions['returnNull']: true
 type ReturnNull = NormalizeByTypeOptions<null, { returnNull: true }>; // Returns null
@@ -33,21 +33,24 @@ const emptyStringValue2: ReturnEmptyString = '';
 const nonEmptyStringValue2: ReturnEmptyString = 'non-empty-string';
 
 // Test cases for TypeOptions['keySeparator']: '.' (default)
-type DefaultCase = AppendKeys<'namespace', 'key' | 'key2'>;
+type DefaultCase = KeysWithSeparator<'namespace', 'key' | 'key2'>;
 const defaultCaseExpectedResult = 'namespace.key';
 const defaultCaseExpectedResult2 = 'namespace.key2';
 const defaultCase: DefaultCase = defaultCaseExpectedResult;
 const defaultCase2: DefaultCase = defaultCaseExpectedResult2;
 
 // Test cases for TypeOptions['keySeparator']: '>>>' (arbitrary separator)
-type ArbitrarySeparatorCase = AppendKeys<'namespace', 'key' | 'key2', '>>>'>;
+type ArbitrarySeparatorCase = KeysWithSeparator<'namespace', 'key' | 'key2', '>>>'>;
 const arbitrarySeparatorExpectedResult = 'namespace>>>key';
 const arbitrarySeparatorExpectedResult2 = 'namespace>>>key2';
 const arbitrarySeparatorCase: ArbitrarySeparatorCase = arbitrarySeparatorExpectedResult;
 const arbitrarySeparatorCase2: ArbitrarySeparatorCase = arbitrarySeparatorExpectedResult2;
 
 // Test cases for TypeOptions['keySeparator']: false (nesting not supported)
-interface MockDictionary { key: { nested: 'value' }; notNested: 'value' };
+interface MockDictionary {
+  key: { nested: 'value' };
+  notNested: 'value';
+}
 
 type ReturnGivenKey = NormalizeReturn<MockDictionary, 'key.nested', false>;
 const shouldBeGivenKey: ReturnGivenKey = 'key.nested';

--- a/ts4.1/index.d.ts
+++ b/ts4.1/index.d.ts
@@ -234,10 +234,10 @@ export interface TFunction<N extends Namespace = DefaultNamespace, TKPrefix = un
   ): TFuncReturn<N, TKeys, TDefaultResult, TKPrefix>;
 }
 
-type I18nKeyType<N extends Namespace> = TFuncKey<N> extends infer A ? A : never;
 export interface TransProps<
-  K extends TFuncKey<N> extends infer A ? A : never,
+  K extends TFuncKey<N, TKPrefix> extends infer A ? A : never,
   N extends Namespace = DefaultNamespace,
+  TKPrefix = undefined,
   E extends Element = HTMLDivElement
 > extends React.HTMLProps<E> {
   children?: React.ReactNode;
@@ -250,14 +250,15 @@ export interface TransProps<
   parent?: string | React.ComponentType<any> | null; // used in React.createElement if not null
   tOptions?: {};
   values?: {};
-  t?: TFunction<N>;
+  t?: TFunction<N, TKPrefix>;
 }
 
 export function Trans<
-  K extends TFuncKey<N> extends infer A ? A : never,
+  K extends TFuncKey<N, TKPrefix> extends infer A ? A : never,
   N extends Namespace = DefaultNamespace,
+  TKPrefix extends KeyPrefix<N> = undefined,
   E extends Element = HTMLDivElement
->(props: TransProps<K, N, E>): React.ReactElement;
+>(props: TransProps<K, N, TKPrefix, E>): React.ReactElement;
 
 export function useSSR(initialI18nStore: Resource, initialLanguage: string): void;
 

--- a/ts4.1/index.d.ts
+++ b/ts4.1/index.d.ts
@@ -102,7 +102,7 @@ type WithOrWithoutPlural<K> = TypeOptions['jsonFormat'] extends 'v4'
   : K;
 
 // Normalize single namespace
-type KeysWithSeparator<K1, K2, S extends string = TypeOptions['keySeparator']> = `${K1 &
+export type KeysWithSeparator<K1, K2, S extends string = TypeOptions['keySeparator']> = `${K1 &
   string}${S}${K2 & string}`;
 type KeysWithSeparator2<K1, K2> = KeysWithSeparator<K1, Exclude<K2, keyof any[]>>;
 type Normalize2<T, K = keyof T> = K extends keyof T


### PR DESCRIPTION
Closes https://github.com/i18next/react-i18next/issues/1387

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided