### PR TITLE
Update macro to wrap defaults in brackets when necessary

### DIFF
--- a/icu.macro.js
+++ b/icu.macro.js
@@ -263,7 +263,10 @@ function buildTransElement(
   // add generated Trans attributes
   if (!attributeExistsAlready('defaults', finalAttributes))
     finalAttributes.push(
-      t.jSXAttribute(t.jSXIdentifier('defaults'), t.StringLiteral(extracted.defaults)),
+      t.jSXAttribute(
+        t.jSXIdentifier('defaults'),
+        t.jSXExpressionContainer(t.StringLiteral(extracted.defaults)),
+      ),
     );
   if (!attributeExistsAlready('components', finalAttributes))
     finalAttributes.push(

--- a/icu.macro.js
+++ b/icu.macro.js
@@ -262,12 +262,20 @@ function buildTransElement(
 
   // add generated Trans attributes
   if (!attributeExistsAlready('defaults', finalAttributes))
-    finalAttributes.push(
-      t.jSXAttribute(
-        t.jSXIdentifier('defaults'),
-        t.jSXExpressionContainer(t.StringLiteral(extracted.defaults)),
-      ),
-    );
+    if (extracted.defaults.includes(`"`)) {
+      // wrap defaults that contain double quotes in brackets
+      finalAttributes.push(
+        t.jSXAttribute(
+          t.jSXIdentifier('defaults'),
+          t.jSXExpressionContainer(t.StringLiteral(extracted.defaults)),
+        ),
+      );
+    } else {
+      finalAttributes.push(
+        t.jSXAttribute(t.jSXIdentifier('defaults'), t.StringLiteral(extracted.defaults)),
+      );
+    }
+
   if (!attributeExistsAlready('components', finalAttributes))
     finalAttributes.push(
       t.jSXAttribute(t.jSXIdentifier('components'), t.jSXExpressionContainer(extracted.components)),

--- a/test/__snapshots__/icu.macro.spec.js.snap
+++ b/test/__snapshots__/icu.macro.spec.js.snap
@@ -572,3 +572,18 @@ const x = <Trans i18nKey=\\"key\\" defaults=\\"<0>exciting!</0>{count, plural, =
 }} />;
 "
 `;
+
+exports[`macros 22. macros: 22. macros 1`] = `
+"
+import { Trans } from \\"../icu.macro\\";
+
+const x = <Trans>Welcome, &quot;{ name }&quot;!</Trans>
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { Trans } from \\"react-i18next\\";
+const x = <Trans defaults={\\"Welcome, \\\\\\"{name}\\\\\\"!\\"} components={[]} values={{
+  name
+}} />;
+"
+`;

--- a/test/icu.macro.spec.js
+++ b/test/icu.macro.spec.js
@@ -301,6 +301,11 @@ pluginTester({
         </Trans>
       );
     `,
+    `
+      import { Trans } from "../icu.macro";
+
+      const x = <Trans>Welcome, &quot;{ name }&quot;!</Trans>
+    `,
     {
       code: `
         import React from "react"


### PR DESCRIPTION
I noticed that the Trans macro generates invalid code when children contains a double quote. From [ast explorer](https://astexplorer.net/#/gist/642aebbb9e449e959f4ad8907b4adf3a/4a65742e2a3e926eb55eaa3d657d1472b9ac7970):

```jsx
// before
<Trans>"</Trans>;
// after
<Trans defaults="\"" components={[]} values={{}} />;
```

According to the [JSX spec](https://facebook.github.io/jsx/#prod-JSXAttributeValue) this isn't valid; JSX doesn't support any kind of escaping inside of `"` quoted attributes. Babel, tsc, prettier, etc all fail when parsing. To get around this we can just wrap the value in brackets. I made it only happen when the string in question contains a quote.

```diff
// before
<Trans>"</Trans>;
// after
- <Trans defaults="\"" components={[]} values={{}} />;
+ <Trans defaults={"\""} components={[]} values={{}} />;
```

I am kinda confused about how this is working today without issue.

I think we could also `defaults.replace(/"/g, "&quot;")` instead if that's preferred.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
