### PR TITLE
Add explicit `children` prop to `I18nextProviderProps`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -107,6 +107,7 @@ export function withTranslation(
 ) => React.ComponentType<Omit<ResolvedProps, keyof WithTranslation> & WithTranslationProps>;
 
 export interface I18nextProviderProps {
+  children?: React.ReactNode;
   i18n: i18n;
   defaultNS?: string;
 }

--- a/ts4.1/index.d.ts
+++ b/ts4.1/index.d.ts
@@ -341,6 +341,7 @@ export function withTranslation<N extends Namespace = DefaultNamespace>(
 ) => React.ComponentType<Omit<ResolvedProps, keyof WithTranslation<N>> & WithTranslationProps>;
 
 export interface I18nextProviderProps {
+  children?: React.ReactNode;
   i18n: i18n;
   defaultNS?: string;
 }


### PR DESCRIPTION
Fixes #1477 by explicitly specifying `children` prop on `I18nextProviderProps`.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included