### PR TITLE
Fix type 'TFunctionResult' is not assignable to type 'ReactNode' on React 18

### DIFF
--- a/ts4.1/index.d.ts
+++ b/ts4.1/index.d.ts
@@ -228,7 +228,7 @@ export type TFuncReturn<
 export interface TFunction<N extends Namespace = DefaultNamespace, TKPrefix = undefined> {
   <
     TKeys extends TFuncKey<N, TKPrefix> | TemplateStringsArray extends infer A ? A : never,
-    TDefaultResult extends TFunctionResult = string,
+    TDefaultResult extends TFunctionResult | ReactNode = string,
     TInterpolationMap extends object = StringMap
   >(
     key: TKeys | TKeys[],
@@ -236,7 +236,7 @@ export interface TFunction<N extends Namespace = DefaultNamespace, TKPrefix = un
   ): TFuncReturn<N, TKeys, TDefaultResult, TKPrefix>;
   <
     TKeys extends TFuncKey<N, TKPrefix> | TemplateStringsArray extends infer A ? A : never,
-    TDefaultResult extends TFunctionResult = string,
+    TDefaultResult extends TFunctionResult | ReactNode = string,
     TInterpolationMap extends object = StringMap
   >(
     key: TKeys | TKeys[],


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

Fixes #1476 by add `ReactNode` to the `TDefaultResult` type

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included