### PR TITLE
Disable no-null-undefined-union for TFunctionResult

### DIFF
--- a/ts4.1/index.d.ts
+++ b/ts4.1/index.d.ts
@@ -228,6 +228,7 @@ export type TFuncReturn<
 export interface TFunction<N extends Namespace = DefaultNamespace, TKPrefix = undefined> {
   <
     TKeys extends TFuncKey<N, TKPrefix> | TemplateStringsArray extends infer A ? A : never,
+    // tslint:disable-next-line:no-null-undefined-union
     TDefaultResult extends TFunctionResult | React.ReactNode = string,
     TInterpolationMap extends object = StringMap
   >(
@@ -236,6 +237,7 @@ export interface TFunction<N extends Namespace = DefaultNamespace, TKPrefix = un
   ): TFuncReturn<N, TKeys, TDefaultResult, TKPrefix>;
   <
     TKeys extends TFuncKey<N, TKPrefix> | TemplateStringsArray extends infer A ? A : never,
+    // tslint:disable-next-line:no-null-undefined-union
     TDefaultResult extends TFunctionResult | React.ReactNode = string,
     TInterpolationMap extends object = StringMap
   >(


### PR DESCRIPTION
Disable no-null-undefined-union rule for TFunctionResult imported from i18next.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided