### PR TITLE
Added objects explicitly to Trans children

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "rollup-plugin-replace": "^2.1.0",
         "rollup-plugin-terser": "^5.1.1",
         "sinon": "^7.2.3",
-        "tslint": "^5.20.1",
+        "tslint": "^6.1.3",
         "typescript": "4.6.2",
         "yargs": "^13.3.0"
       },
@@ -14614,9 +14614,10 @@
       "dev": true
     },
     "node_modules/tslint": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
-      "integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.3.tgz",
+      "integrity": "sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==",
+      "deprecated": "TSLint has been deprecated in favor of ESLint. Please see https://github.com/palantir/tslint/issues/4534 for more information.",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -14627,10 +14628,10 @@
         "glob": "^7.1.1",
         "js-yaml": "^3.13.1",
         "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
+        "mkdirp": "^0.5.3",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
-        "tslib": "^1.8.0",
+        "tslib": "^1.13.0",
         "tsutils": "^2.29.0"
       },
       "bin": {
@@ -14640,7 +14641,7 @@
         "node": ">=4.8.0"
       },
       "peerDependencies": {
-        "typescript": ">=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev"
+        "typescript": ">=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 4.0.0-dev"
       }
     },
     "node_modules/tslint/node_modules/commander": {
@@ -26750,9 +26751,9 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
-      "integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.3.tgz",
+      "integrity": "sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -26763,10 +26764,10 @@
         "glob": "^7.1.1",
         "js-yaml": "^3.13.1",
         "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
+        "mkdirp": "^0.5.3",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
-        "tslib": "^1.8.0",
+        "tslib": "^1.13.0",
         "tsutils": "^2.29.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "rollup-plugin-replace": "^2.1.0",
     "rollup-plugin-terser": "^5.1.1",
     "sinon": "^7.2.3",
-    "tslint": "^5.20.1",
+    "tslint": "^6.1.3",
     "typescript": "4.6.2",
     "yargs": "^13.3.0"
   },

--- a/ts4.1/index.d.ts
+++ b/ts4.1/index.d.ts
@@ -228,7 +228,6 @@ export type TFuncReturn<
 export interface TFunction<N extends Namespace = DefaultNamespace, TKPrefix = undefined> {
   <
     TKeys extends TFuncKey<N, TKPrefix> | TemplateStringsArray extends infer A ? A : never,
-    // tslint:disable-next-line:no-null-undefined-union
     TDefaultResult extends TFunctionResult | React.ReactNode = string,
     TInterpolationMap extends object = StringMap
   >(
@@ -237,7 +236,6 @@ export interface TFunction<N extends Namespace = DefaultNamespace, TKPrefix = un
   ): TFuncReturn<N, TKeys, TDefaultResult, TKPrefix>;
   <
     TKeys extends TFuncKey<N, TKPrefix> | TemplateStringsArray extends infer A ? A : never,
-    // tslint:disable-next-line:no-null-undefined-union
     TDefaultResult extends TFunctionResult | React.ReactNode = string,
     TInterpolationMap extends object = StringMap
   >(
@@ -253,7 +251,7 @@ export type TransProps<
   TKPrefix = undefined,
   E = React.HTMLProps<HTMLDivElement>
 > = E & {
-  children?: React.ReactNode;
+  children?: React.ReactNode | Record<string, unknown>;
   components?: readonly React.ReactNode[] | { readonly [tagName: string]: React.ReactNode };
   count?: number;
   context?: string;

--- a/tslint.json
+++ b/tslint.json
@@ -3,6 +3,7 @@
   "extends": "dtslint/dtslint.json",
   "rules": {
     "array-type": [true, "array"],
+    "no-null-undefined-union": false,
     "no-empty-interface": false,
     "no-redundant-jsdoc": false,
     "no-unnecessary-generics": false,


### PR DESCRIPTION
Fixes #1483.

Allows objects to be passed to Trans component with @types/react@18.
#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided