### PR TITLE
fix Translation component types regression

### DIFF
--- a/ts4.1/index.d.ts
+++ b/ts4.1/index.d.ts
@@ -368,7 +368,10 @@ export interface I18nextProviderProps {
 export const I18nextProvider: React.FunctionComponent<I18nextProviderProps>;
 export const I18nContext: React.Context<{ i18n: i18n }>;
 
-export interface TranslationProps<N extends Namespace = DefaultNamespace, TKPrefix> {
+export interface TranslationProps<
+  N extends Namespace = DefaultNamespace,
+  TKPrefix extends KeyPrefix<N> = undefined
+> {
   children: (
     t: TFunction<N, TKPrefix>,
     options: {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

Fixes the error that typescript started raising since last release 11.16.10:
```
Error: [...]react-i18next/ts4.1/index.d.ts(371,75): error TS2706: Required type parameters may not follow optional type parameters.
```

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided