### PR TITLE
Stricter typescript type for Trans components prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,7 +34,7 @@ export interface TransProps<E extends Element = HTMLDivElement>
   extends React.HTMLProps<E>,
     Partial<WithT> {
   children?: React.ReactNode;
-  components?: readonly React.ReactNode[] | { readonly [tagName: string]: React.ReactNode };
+  components?: readonly React.ReactElement[] | { readonly [tagName: string]: React.ReactElement };
   count?: number;
   context?: string;
   defaults?: string;

--- a/package.json
+++ b/package.json
@@ -117,9 +117,9 @@
     "test:watch": "cross-env BABEL_ENV=development jest --no-cache --watch",
     "test:coverage": "cross-env BABEL_ENV=development jest --no-cache --coverage",
     "test:lint": "eslint ./src ./test",
-    "test:typescript": "tslint --project tsconfig.json '**/*.ts'",
-    "test:typescript:noninterop": "tslint --project tsconfig.nonEsModuleInterop.json '**/*.ts'",
-    "test:typescript:customtypes": "tslint --project ./test/typescript/custom-types/tsconfig.json '**/*.ts'",
+    "test:typescript": "tslint --project tsconfig.json '**/*.{ts,tsx}'",
+    "test:typescript:noninterop": "tslint --project tsconfig.nonEsModuleInterop.json '**/*.{ts,tsx}'",
+    "test:typescript:customtypes": "tslint --project ./test/typescript/custom-types/tsconfig.json '**/*.{ts,tsx}'",
     "contributors:add": "all-contributors add",
     "contributors:generate": "all-contributors generate",
     "prettier": "prettier --write \"{,**/}*.{ts,tsx,js,json,md}\""

--- a/test/trans.render.object.spec.js
+++ b/test/trans.render.object.spec.js
@@ -242,32 +242,3 @@ describe('trans using no children but components (object) - interpolated compone
     `);
   });
 });
-
-describe('trans using no children but components (object) - ReactNodes that error', () => {
-  const Button = ({ children }) => <button type="button">{children}</button>;
-  // Suppress console.errors in these tests
-  let consoleErrorFn;
-  beforeAll(() => {
-    consoleErrorFn = jest.spyOn(console, 'error').mockImplementation(() => jest.fn());
-  });
-  afterAll(() => {
-    consoleErrorFn.restoreMocks();
-  });
-  it('should throw if you use some valid ReactNodes', () => {
-    expect(() =>
-      render(<Trans defaults="hello <ClickMe>Test</ClickMe>" components={{ ClickMe: Button }} />),
-    ).toThrow();
-
-    expect(() =>
-      render(<Trans defaults="hello <ClickMe>Test</ClickMe>" components={{ ClickMe: {} }} />),
-    ).toThrow();
-
-    expect(() =>
-      render(<Trans defaults="hello <ClickMe>Test</ClickMe>" components={{ ClickMe: null }} />),
-    ).toThrow();
-
-    expect(() =>
-      render(<Trans defaults="hello <ClickMe>Test</ClickMe>" components={{ ClickMe: true }} />),
-    ).toThrow();
-  });
-});

--- a/test/trans.render.object.spec.js
+++ b/test/trans.render.object.spec.js
@@ -242,3 +242,32 @@ describe('trans using no children but components (object) - interpolated compone
     `);
   });
 });
+
+describe('trans using no children but components (object) - ReactNodes that error', () => {
+  const Button = ({ children }) => <button type="button">{children}</button>;
+  // Suppress console.errors in these tests
+  let consoleErrorFn;
+  beforeAll(() => {
+    consoleErrorFn = jest.spyOn(console, 'error').mockImplementation(() => jest.fn());
+  });
+  afterAll(() => {
+    consoleErrorFn.restoreMocks();
+  });
+  it('should throw if you use some valid ReactNodes', () => {
+    expect(() =>
+      render(<Trans defaults="hello <ClickMe>Test</ClickMe>" components={{ ClickMe: Button }} />),
+    ).toThrow();
+
+    expect(() =>
+      render(<Trans defaults="hello <ClickMe>Test</ClickMe>" components={{ ClickMe: {} }} />),
+    ).toThrow();
+
+    expect(() =>
+      render(<Trans defaults="hello <ClickMe>Test</ClickMe>" components={{ ClickMe: null }} />),
+    ).toThrow();
+
+    expect(() =>
+      render(<Trans defaults="hello <ClickMe>Test</ClickMe>" components={{ ClickMe: true }} />),
+    ).toThrow();
+  });
+});

--- a/test/typescript/Trans.test.tsx
+++ b/test/typescript/Trans.test.tsx
@@ -26,27 +26,12 @@ function objectComponents() {
   return <Trans components={{ Btn: <button /> }} defaults="Hello <Btn />" />;
 }
 
-function MyComponent(): React.ReactElement {
+function MyComponent() {
   return <>world</>;
 }
 
 function objectCustomComponents() {
   return <Trans components={{ Btn: <MyComponent /> }} defaults="Hello <Btn />" />;
-}
-
-function objectCustomComponentsShouldError() {
-  return (
-    <Trans
-      // Valid ReactNodes according to types
-      components={{
-        Btn: MyComponent,
-        Btn2: null,
-        Btn4: true,
-        Btn5: {},
-      }}
-      defaults="Hello <Btn /><Btn2 /><Btn3 /><Btn4 /><Btn5 />"
-    />
-  );
 }
 
 function constObjectComponents() {

--- a/test/typescript/Trans.test.tsx
+++ b/test/typescript/Trans.test.tsx
@@ -26,6 +26,29 @@ function objectComponents() {
   return <Trans components={{ Btn: <button /> }} defaults="Hello <Btn />" />;
 }
 
+function MyComponent(): React.ReactElement {
+  return <>world</>;
+}
+
+function objectCustomComponents() {
+  return <Trans components={{ Btn: <MyComponent /> }} defaults="Hello <Btn />" />;
+}
+
+function objectCustomComponentsShouldError() {
+  return (
+    <Trans
+      // Valid ReactNodes according to types
+      components={{
+        Btn: MyComponent,
+        Btn2: null,
+        Btn4: true,
+        Btn5: {},
+      }}
+      defaults="Hello <Btn /><Btn2 /><Btn3 /><Btn4 /><Btn5 />"
+    />
+  );
+}
+
 function constObjectComponents() {
   const constObject = {
     Btn: <button />,

--- a/ts4.1/index.d.ts
+++ b/ts4.1/index.d.ts
@@ -264,7 +264,7 @@ export type TransProps<
   E = React.HTMLProps<HTMLDivElement>
 > = E & {
   children?: TransChild | TransChild[];
-  components?: readonly React.ReactNode[] | { readonly [tagName: string]: React.ReactNode };
+  components?: readonly React.ReactElement[] | { readonly [tagName: string]: React.ReactElement };
   count?: number;
   context?: string;
   defaults?: string;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

Since the values in the components prop are being passed to cloneElement only the ReactElement type is really supported. All other types accepted by ReactNode will cause a runtime error. You can test this by checking out the first two commits in this branch.

- d8904f768ae5aad951197e736e62152e460101fd: Types pass but as the unit test shows react throws
- 563966bcab519ca6ac26fd9d930bda0275cc7519: Corrected types: tslint now fails
- 516fbdc7ecbc6d1adfa653f902ec0b51b9dd3d7c & 9509d54ab799bbca59356b8acf96627f23441e75: I removed the example typescript error and tests for invalid behaviour

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided