### PR TITLE
allow iterable with objects as children

### DIFF
--- a/ts4.1/index.d.ts
+++ b/ts4.1/index.d.ts
@@ -102,9 +102,12 @@ declare module 'i18next' {
 type ObjectOrNever = TypeOptions['allowObjectInHTMLChildren'] extends true
   ? Record<string, unknown>
   : never;
+
+type ReactI18NextChild = React.ReactNode | ObjectOrNever;
+
 declare module 'react' {
   interface HTMLAttributes<T> {
-    children?: ReactNode | ObjectOrNever;
+    children?: ReactI18NextChild | Iterable<ReactI18NextChild>;
   }
 }
 


### PR DESCRIPTION
This PR fixes TypeScript error which prevents multiple nodes to be used inside core React elements when `allowObjectInHTMLChildren` is set to true.

Code example that fails on the latest published version with React 18 but works correctly with this PR:

```tsx
<Trans t={t}>
  View <b>{{ count }} cards</b>
</Trans>
```

Resolves #1506

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)