### PR TITLE
more html entities to unescape by default

### DIFF
--- a/src/unescape.js
+++ b/src/unescape.js
@@ -1,4 +1,6 @@
-const matchHtmlEntity = /&(?:amp|#38|lt|#60|gt|#62|apos|#39|quot|#34);/g;
+// unescape common html entities
+
+const matchHtmlEntity = /&(?:amp|#38|lt|#60|gt|#62|apos|#39|quot|#34|nbsp|#160|copy|#169|reg|#174|hellip|#8230);/g;
 
 const htmlEntities = {
   '&amp;': '&',
@@ -11,6 +13,14 @@ const htmlEntities = {
   '&#39;': "'",
   '&quot;': '"',
   '&#34;': '"',
+  '&nbsp;': ' ',
+  '&#160;': ' ',
+  '&copy;': '©',
+  '&#169;': '©',
+  '&reg;': '®',
+  '&#174;': '®',
+  '&hellip;': '…',
+  '&#8230;': '…',
 };
 
 const unescapeHtmlEntity = (m) => htmlEntities[m];

--- a/test/trans.render.spec.js
+++ b/test/trans.render.spec.js
@@ -636,7 +636,7 @@ describe('trans should allow escaped html', () => {
         <a
           href="/msgs"
         >
-          &lt;&nbsp;&&gt;
+          &lt; &&gt;
         </a>
         .
       </div>

--- a/test/unescape.spec.js
+++ b/test/unescape.spec.js
@@ -1,0 +1,11 @@
+import { unescape } from '../src/unescape';
+
+describe('unescape', () => {
+  it('should correctly unescape', () => {
+    const unescaped = unescape(
+      '&amp; &#38; &lt; &#60; &gt; &#62; &apos; &#39; &quot; &#34; &nbsp; &#160; &copy; &#169; &reg; &#174; &hellip; &#8230;',
+    );
+
+    expect(unescaped).toEqual('& & < < > > \' \' " "     © © ® ® … …');
+  });
+});


### PR DESCRIPTION
Adds more html entities to unescape without the need of a custom unescape function.
Changes also how spaces are unescaped now. Also the Trans render test needed to be adapted. Will this have an influence with existing `&nbsp;` usage?

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

