### PR TITLE
Fix console warning in preact due to  Trans accessing node.children first

### DIFF
--- a/src/Trans.js
+++ b/src/Trans.js
@@ -12,7 +12,7 @@ function hasChildren(node, checkLength) {
 
 function getChildren(node) {
   if (!node) return [];
-  return node && node.children ? node.children : node.props && node.props.children;
+  return node.props ? node.props.children : node.children;
 }
 
 function hasValidReactChildren(children) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

- `react-i18next` when used with the latest `preact` version throws a console warning related to accessing a deprecated property (see screenshot)
-  When [upgrading from preact 8.x](https://preactjs.com/guide/v10/upgrade-guide/#notes-for-library-authors) the `VNODE` structure in `preact` was changed from `children -> props.children`
-  when `getChildren` function in `src/Trans.js` tries to access `node.children` first, `preact` throws a deprecated API console warning
- one of the ways to fix this is to follow the same pattern we do in [`hasChildren` function](https://github.com/i18next/react-i18next/blob/master/src/Trans.js#L8) i.e try to access `node.props.children` first if `node.props` exists
- This PR includes that change

![image](https://user-images.githubusercontent.com/2181515/181743154-b58e1153-f6ca-4e9e-88b0-c20868109203.png)


#### Checklist
- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
