### PR TITLE
support unescaping forward slash

### DIFF
--- a/src/unescape.js
+++ b/src/unescape.js
@@ -1,6 +1,6 @@
 // unescape common html entities
 
-const matchHtmlEntity = /&(?:amp|#38|lt|#60|gt|#62|apos|#39|quot|#34|nbsp|#160|copy|#169|reg|#174|hellip|#8230);/g;
+const matchHtmlEntity = /&(?:amp|#38|lt|#60|gt|#62|apos|#39|quot|#34|nbsp|#160|copy|#169|reg|#174|hellip|#8230|#x2F);/g;
 
 const htmlEntities = {
   '&amp;': '&',
@@ -21,6 +21,7 @@ const htmlEntities = {
   '&#174;': '®',
   '&hellip;': '…',
   '&#8230;': '…',
+  '&#x2F;': '/',
 };
 
 const unescapeHtmlEntity = (m) => htmlEntities[m];

--- a/test/unescape.spec.js
+++ b/test/unescape.spec.js
@@ -3,9 +3,9 @@ import { unescape } from '../src/unescape';
 describe('unescape', () => {
   it('should correctly unescape', () => {
     const unescaped = unescape(
-      '&amp; &#38; &lt; &#60; &gt; &#62; &apos; &#39; &quot; &#34; &nbsp; &#160; &copy; &#169; &reg; &#174; &hellip; &#8230;',
+      '&amp; &#38; &lt; &#60; &gt; &#62; &apos; &#39; &quot; &#34; &nbsp; &#160; &copy; &#169; &reg; &#174; &hellip; &#8230; &#x2F;',
     );
 
-    expect(unescaped).toEqual('& & < < > > \' \' " "     © © ® ® … …');
+    expect(unescaped).toEqual('& & < < > > \' \' " "     © © ® ® … … /');
   });
 });


### PR DESCRIPTION
Adds support for unescaping the `/` character. This is one of the characters that i18next itself escapes so I think this is a must.

This fixes #1487 which is closed but not fixed.

Note I have only handled exactly `&#x2F`, case sensitively. This is what i18next's escaper produces so it's enough to fix the issue. Handling case insensitivity would be a further improvement, though this applies to some of the existing codes too. It's not completely trivial. For example, some entities support all-lowercase and all-uppercase versions but not mixtures, and some only support lowercase. For example, `&amp;` and `&AMP;` are both valid versions of the ampersand, but `&aMp;` is not. However for ellipsis, only `&hellip;` is supported, `&HELLIP;` is not. The numeric codes like `&#x2F` appear to support any mixture of case.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)