### PR TITLE
Fix performance issue in `Trans` component

### DIFF
--- a/TransWithoutContext.d.ts
+++ b/TransWithoutContext.d.ts
@@ -1,12 +1,4 @@
-import type {
-  i18n,
-  ParseKeys,
-  Namespace,
-  TypeOptions,
-  TOptions,
-  TFunction,
-  KeyPrefix,
-} from 'i18next';
+import type { i18n, ParseKeys, Namespace, TypeOptions, TOptions, TFunction } from 'i18next';
 import * as React from 'react';
 
 type _DefaultNamespace = TypeOptions['defaultNS'];
@@ -38,6 +30,6 @@ export function Trans<
   Key extends ParseKeys<Ns, TOpt, KPrefix>,
   Ns extends Namespace = _DefaultNamespace,
   TOpt extends TOptions = {},
-  KPrefix extends KeyPrefix<Ns> = undefined,
+  KPrefix = undefined,
   E = React.HTMLProps<HTMLDivElement>,
 >(props: TransProps<Key, Ns, TOpt, KPrefix, E>): React.ReactElement;


### PR DESCRIPTION
Closes https://github.com/i18next/react-i18next/issues/1601

Identifying the source of the problem was challenging, but thanks to a reproducible example shared by @sebastien-comeau, I was able to identify the root cause.

By default, when the `t` function is not passed, the inferred value for `KPrefix` should be `undefined`. However, due to a TypeScript limitation, the `KPrefix` was not maintaining its default signature of `undefined` and instead was inferring all keys from the `KeyPrefix`. This caused the `ParseKeys` function to map over the entire list of keys and key prefixes in order to filter out the keys that started with every `KPrefix` value. 

As a result, using the `Trans` component without specifying a `KPrefix` value could lead to an unnecessary exponential increase in the number of type inspections. This increase is due to the fact that `ParseKeys` would have to perform a large number of inspections for every possible combination of namespaces, keys, and key prefixes. Specifically, this increase in inspections can be characterized as `Namespaces * Keys * Key Prefix`. 

To avoid this performance issue, I remove the constraint value from `KPrefix` (which, in this case, brings no benefit). By removing the constraint value, `KPrefix` maintains its default value (`undefined`) and avoids unnecessary inspections.

![Screenshot 2023-06-21 at 6 07 01 PM](https://github.com/i18next/react-i18next/assets/12190482/75b026a3-bc7b-483d-9ddd-cf3b35d84f37)


#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)