### PR TITLE
Render all children regardless of type when using i18nIsDynamicList prop

### DIFF
--- a/src/TransWithoutContext.js
+++ b/src/TransWithoutContext.js
@@ -139,7 +139,12 @@ function renderNodes(children, targetString, i18n, i18nOptions, combinedTOpts, s
   function renderInner(child, node, rootReactNode) {
     const childs = getChildren(child);
     const mappedChildren = mapAST(childs, node.children, rootReactNode);
-    return hasValidReactChildren(childs) && mappedChildren.length === 0 ? childs : mappedChildren;
+    // `mappedChildren` will always be empty if using the `i18nIsDynamicList` prop,
+    // but the children might not necessarily be react components
+    return (hasValidReactChildren(childs) && mappedChildren.length === 0) ||
+      child.props?.i18nIsDynamicList
+      ? childs
+      : mappedChildren;
   }
 
   function pushTranslatedJSX(child, inner, mem, i, isVoid) {

--- a/test/trans.render.dynamic.spec.js
+++ b/test/trans.render.dynamic.spec.js
@@ -69,7 +69,7 @@ describe('Trans should render nested components', () => {
     `);
   });
 
-  it('should render dynamic content correctly', () => {
+  it('should render dynamic Elements correctly', () => {
     const dynamicContent = <div>testing</div>;
 
     function TestComponent() {
@@ -87,6 +87,25 @@ describe('Trans should render nested components', () => {
         <div>
           testing
         </div>
+      </div>
+    `);
+  });
+
+  it('should render dynamic strings correctly', () => {
+    const dynamicContent = 'testing';
+
+    function TestComponent() {
+      return (
+        <Trans>
+          My dynamic content: <React.Fragment i18nIsDynamicList>{dynamicContent}</React.Fragment>
+        </Trans>
+      );
+    }
+    const { container } = render(<TestComponent />);
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <div>
+        My dynamic content: 
+        testing
       </div>
     `);
   });


### PR DESCRIPTION
Hi @adrai, this is followup to #1660. I noticed that rendering was still not working when using dynamic strings. This PR fixes that.

#### Checklist
- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)