### PR TITLE
Allow iterable `ReactI18NextChildren` as children

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -52,7 +52,10 @@ type ReactI18NextChildren = React.ReactNode | ObjectOrNever;
 
 declare module 'react' {
   interface HTMLAttributes<T> {
-    children?: ReactI18NextChildren;
+    // This union is inspired by the typings for React.ReactNode. We do this to fix "This JSX tag's 'children' prop
+    // expects a single child of type 'ReactI18NextChildren', but multiple children were provided":
+    // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/5a1e9f91ed0143adede394adb3f540e650455f71/types/react/index.d.ts#L268
+    children?: ReactI18NextChildren | Iterable<ReactI18NextChildren>;
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^11.2.7",
         "@testing-library/react-hooks": "^3.4.2",
+        "@types/react": "^18.2.21",
         "all-contributors-cli": "^6.26.0",
         "babel-core": "^7.0.0-bridge.0",
         "babel-jest": "^24.8.0",
@@ -3934,9 +3935,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "17.0.11",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.11.tgz",
-      "integrity": "sha512-yFRQbD+whVonItSk7ZzP/L+gPTJVBkL/7shLEF+i9GC/1cV3JmUxEQz6+9ylhUpWSDuqo1N9qEvqS6vTj4USUA==",
+      "version": "18.2.21",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.21.tgz",
+      "integrity": "sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -19596,9 +19597,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "17.0.11",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.11.tgz",
-      "integrity": "sha512-yFRQbD+whVonItSk7ZzP/L+gPTJVBkL/7shLEF+i9GC/1cV3JmUxEQz6+9ylhUpWSDuqo1N9qEvqS6vTj4USUA==",
+      "version": "18.2.21",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.21.tgz",
+      "integrity": "sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^11.2.7",
     "@testing-library/react-hooks": "^3.4.2",
+    "@types/react": "^18.2.21",
     "all-contributors-cli": "^6.26.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^24.8.0",

--- a/test/typescript/Trans.test.tsx
+++ b/test/typescript/Trans.test.tsx
@@ -96,3 +96,12 @@ function extraDivProps() {
     </>
   );
 }
+
+function objectChild() {
+  return (
+    <Trans>
+      {/* @ts-expect-error */}
+      <span>This {{ var: '' }} is an error since `allowObjectInHTMLChildren` is disabled</span>
+    </Trans>
+  );
+}

--- a/test/typescript/custom-types/Trans.test.tsx
+++ b/test/typescript/custom-types/Trans.test.tsx
@@ -95,3 +95,23 @@ function withTfunctionAndKeyPrefixAndWrongKey() {
     </Trans>
   );
 }
+
+function withTextAndInterpolation() {
+  return <Trans>foo {{ var: '' }}</Trans>;
+}
+
+function withInterpolationInHTMLElement() {
+  return (
+    <Trans>
+      foo <strong>{{ var: '' }}</strong>
+    </Trans>
+  );
+}
+
+function withTextAndInterpolationChildrenInHTMLElement() {
+  return (
+    <Trans>
+      <span>foo {{ var: '' }}</span>
+    </Trans>
+  );
+}

--- a/test/typescript/custom-types/custom-types.d.ts
+++ b/test/typescript/custom-types/custom-types.d.ts
@@ -3,6 +3,7 @@ import 'i18next';
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: 'custom';
+    allowObjectInHTMLChildren: true;
     resources: {
       custom: {
         foo: 'foo';


### PR DESCRIPTION
Fixes issues where interpolations alongside other HTML element children would trigger TypeScript errors. Added tests to make sure this stays working.

Note: I went with React 18 typings becuase React 16 typings allowed for objects to be passed as children, which made it hard to test that our `allowObjectInHTMLChildren` option was working correctly. This shouldn't affect end-users since it's a development dependency.

#### Checklist
- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)