### PR TITLE
fix(context): add pure annotation to allow tree-shaking

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -3,9 +3,9 @@ import { getDefaults, setDefaults } from './defaults.js';
 import { getI18n, setI18n } from './i18nInstance.js';
 import { initReactI18next } from './initReactI18next.js';
 
-export { getDefaults, setDefaults, getI18n, setI18n, initReactI18next };
+export { getDefaults, getI18n, initReactI18next, setDefaults, setI18n };
 
-export const I18nContext = createContext();
+export const I18nContext = /* #__PURE__ */ createContext();
 
 export class ReportNamespaces {
   constructor() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

Apparently the createContext prevents the file from been tree shaked from the esbuild bundler 

i created a playground [here](https://hyrious.me/esbuild-repl/?version=0.19.4&b=e%00entry.js%00import+%7BB%7D+from+%27.%2Ffile2.js%27%0A%0Aconsole.log%28B%28%29%29&b=%00file.js%00import+%7BcreateContext%7D+from+%27react%27%0A%0Aexport+const+context+%3D+%2F*+%23__PURE__+*%2F+createContext%28%29%3B%0A%0Aexport+const+A+%3D+%27a%27%3B&b=%00file2.js%00import+%7BA%7D+from+%27.%2Ffile.js%27%0A%0Aexport+const+B+%3D+function+%28%29%7B%0A++return+%27hello+world%27%0A%7D&i=react%4018.2.0&o=--platform%3Dbrowser+--format%3Desm+--bundle+--external%3Areact+) to replicate my issue.

when removing the `/* #__PURE__ */` annotation it doesn't matter that the context is not used anywhere, the bundle cannot treeShake.


I saw similar similar changes on other libraries to improve tree-shaking ([ref](https://github.com/reduxjs/react-redux/issues/1470))


#### Checklist

- [ ] only relevant code is changed (make a diff before you submit the PR)
- [ ] run tests `npm run test`
- [ ] tests are included
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)