### PR TITLE
types(Trans): add typechecking on `context` prop

### DIFF
--- a/TransWithoutContext.d.ts
+++ b/TransWithoutContext.d.ts
@@ -7,14 +7,15 @@ type TransChild = React.ReactNode | Record<string, unknown>;
 export type TransProps<
   Key extends ParseKeys<Ns, TOpt, KPrefix>,
   Ns extends Namespace = _DefaultNamespace,
-  TOpt extends TOptions = {},
   KPrefix = undefined,
+  TContext extends string | undefined = undefined,
+  TOpt extends TOptions & { context?: TContext } = { context: TContext },
   E = React.HTMLProps<HTMLDivElement>,
 > = E & {
   children?: TransChild | readonly TransChild[];
   components?: readonly React.ReactElement[] | { readonly [tagName: string]: React.ReactElement };
   count?: number;
-  context?: string;
+  context?: TContext;
   defaults?: string;
   i18n?: i18n;
   i18nKey?: Key | Key[];
@@ -29,7 +30,8 @@ export type TransProps<
 export function Trans<
   Key extends ParseKeys<Ns, TOpt, KPrefix>,
   Ns extends Namespace = _DefaultNamespace,
-  TOpt extends TOptions = {},
   KPrefix = undefined,
+  TContext extends string | undefined = undefined,
+  TOpt extends TOptions & { context?: TContext } = { context: TContext },
   E = React.HTMLProps<HTMLDivElement>,
->(props: TransProps<Key, Ns, TOpt, KPrefix, E>): React.ReactElement;
+>(props: TransProps<Key, Ns, KPrefix, TContext, TOpt, E>): React.ReactElement;

--- a/test/typescript/custom-types/Trans.test.tsx
+++ b/test/typescript/custom-types/Trans.test.tsx
@@ -72,25 +72,25 @@ describe('<Trans />', () => {
       const { t } = useTranslation('alternate', { keyPrefix: 'foobar.deep' });
 
       // <Trans t={t} i18nKey="deeper.deeeeeper">foo</Trans>
-      expectTypeOf<
-        typeof Trans<'deeper.deeeeeper', 'alternate', {}, 'foobar.deep'>
-      >().toBeCallableWith({
-        t,
-        i18nKey: 'deeper.deeeeeper',
-      });
+      expectTypeOf<typeof Trans<'deeper.deeeeeper', 'alternate', 'foobar.deep'>>().toBeCallableWith(
+        {
+          t,
+          i18nKey: 'deeper.deeeeeper',
+        },
+      );
     });
 
     it('should throw error with `t` function with key prefix and wrong `i18nKey`', () => {
       const { t } = useTranslation('alternate', { keyPrefix: 'foobar.deep' });
 
       // <Trans t={t} i18nKey="xxx">foo</Trans>
-      expectTypeOf<
-        typeof Trans<'deeper.deeeeeper', 'alternate', {}, 'foobar.deep'>
-      >().toBeCallableWith({
-        t,
-        // @ts-expect-error
-        i18nKey: 'xxx',
-      });
+      expectTypeOf<typeof Trans<'deeper.deeeeeper', 'alternate', 'foobar.deep'>>().toBeCallableWith(
+        {
+          t,
+          // @ts-expect-error
+          i18nKey: 'xxx',
+        },
+      );
     });
   });
 

--- a/test/typescript/custom-types/TransWithoutContext.test.tsx
+++ b/test/typescript/custom-types/TransWithoutContext.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expectTypeOf } from 'vitest';
+import { describe, it, expectTypeOf, assertType } from 'vitest';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Trans } from '../../../TransWithoutContext';
@@ -73,25 +73,25 @@ describe('<Trans />', () => {
       const { t } = useTranslation('alternate', { keyPrefix: 'foobar.deep' });
 
       // <Trans t={t} i18nKey="deeper.deeeeeper">foo</Trans>
-      expectTypeOf<
-        typeof Trans<'deeper.deeeeeper', 'alternate', {}, 'foobar.deep'>
-      >().toBeCallableWith({
-        t,
-        i18nKey: 'deeper.deeeeeper',
-      });
+      expectTypeOf<typeof Trans<'deeper.deeeeeper', 'alternate', 'foobar.deep'>>().toBeCallableWith(
+        {
+          t,
+          i18nKey: 'deeper.deeeeeper',
+        },
+      );
     });
 
     it('should throw error with `t` function with key prefix and wrong `i18nKey`', () => {
       const { t } = useTranslation('alternate', { keyPrefix: 'foobar.deep' });
 
       // <Trans t={t} i18nKey="xxx">foo</Trans>
-      expectTypeOf<
-        typeof Trans<'deeper.deeeeeper', 'alternate', {}, 'foobar.deep'>
-      >().toBeCallableWith({
-        t,
-        // @ts-expect-error
-        i18nKey: 'xxx',
-      });
+      expectTypeOf<typeof Trans<'deeper.deeeeeper', 'alternate', 'foobar.deep'>>().toBeCallableWith(
+        {
+          t,
+          // @ts-expect-error
+          i18nKey: 'xxx',
+        },
+      );
     });
   });
 
@@ -116,6 +116,52 @@ describe('<Trans />', () => {
       expectTypeOf(Trans).toBeCallableWith({
         children: <span>foo {{ var: '' }}</span>,
       });
+    });
+  });
+
+  describe('usage with context', () => {
+    it('should work with default namespace', () => {
+      assertType<React.ReactElement>(<Trans i18nKey="some" context="me" />);
+
+      // @ts-expect-error should throw error when context is not valid
+      assertType<React.ReactElement>(<Trans i18nKey="some" context="one" />);
+    });
+
+    it('should work with `ns` prop', () => {
+      assertType<React.ReactElement>(<Trans ns="context" i18nKey="beverage" />);
+
+      assertType<React.ReactElement>(
+        // @ts-expect-error should throw error when context is not valid
+        <Trans ns="context" i18nKey="beverage" context="strawberry" />,
+      );
+    });
+
+    it('should work with default `t` function', () => {
+      const { t } = useTranslation();
+
+      assertType<React.ReactElement>(<Trans t={t} i18nKey="some" context="me" />);
+
+      // @ts-expect-error should throw error when context is not valid
+      assertType<React.ReactElement>(<Trans t={t} i18nKey="some" context="Test1222" />);
+    });
+
+    it('should work with custom `t` function', () => {
+      const { t } = useTranslation('context');
+
+      assertType<React.ReactElement>(<Trans t={t} i18nKey="dessert" context="cake" />);
+
+      // @ts-expect-error should throw error when context is not valid
+      assertType<React.ReactElement>(<Trans t={t} i18nKey="dessert" context="sake" />);
+    });
+
+    it('should work with `ns` prop and `count` prop', () => {
+      const { t } = useTranslation('plurals');
+      assertType<React.ReactElement>(<Trans ns="plurals" i18nKey="foo" count={2} />);
+    });
+
+    it('should work with custom `t` function and `count` prop', () => {
+      const { t } = useTranslation('plurals');
+      assertType<React.ReactElement>(<Trans t={t} i18nKey="foo" count={2} />);
     });
   });
 });

--- a/test/typescript/custom-types/i18next.d.ts
+++ b/test/typescript/custom-types/i18next.d.ts
@@ -8,9 +8,11 @@ declare module 'i18next' {
       custom: {
         foo: 'foo';
         bar: 'bar';
+
         some: 'some';
         some_me: 'some context';
       };
+
       alternate: {
         baz: 'baz';
         foobar: {
@@ -22,12 +24,22 @@ declare module 'i18next' {
           };
         };
       };
+
       plurals: {
         foo_zero: 'foo';
         foo_one: 'foo';
         foo_two: 'foo';
         foo_many: 'foo';
         foo_other: 'foo';
+      };
+
+      context: {
+        dessert_cake: 'a nice cake';
+        dessert_muffin_one: 'a nice muffin';
+        dessert_muffin_other: '{{count}} nice muffins';
+
+        beverage: 'beverage';
+        beverage_beer: 'beer';
       };
     };
   }

--- a/test/typescript/misc/Trans.test.tsx
+++ b/test/typescript/misc/Trans.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expectTypeOf, it } from 'vitest';
+import { assertType, describe, expectTypeOf, it } from 'vitest';
 import * as React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
@@ -95,14 +95,14 @@ describe('<Trans />', () => {
     );
     expectTypeOf(Trans).toBeCallableWith({ parent: CustomRedComponent, children: 'Foo' });
 
-    <Trans parent="div" style={{ color: 'green' }}>
-      Foo
-    </Trans>;
+    assertType<React.ReactElement>(
+      <Trans parent="div" style={{ color: 'green' }}>
+        Foo
+      </Trans>,
+    );
 
-    {
-      /* div is the default parent */
-    }
-    <Trans style={{ color: 'green' }}>Foo</Trans>;
+    /* div is the default parent */
+    assertType<React.ReactElement>(<Trans style={{ color: 'green' }}>Foo</Trans>);
   });
 
   it('should work with `tOptions`', () => {
@@ -124,9 +124,11 @@ describe('<Trans />', () => {
   });
 
   it('should not work with object child', () => {
-    <Trans>
-      {/* @ts-expect-error */}
-      <span>This {{ var: '' }} is an error since `allowObjectInHTMLChildren` is disabled</span>
-    </Trans>;
+    assertType<React.ReactElement>(
+      <Trans>
+        {/* @ts-expect-error */}
+        <span>This {{ var: '' }} is an error since `allowObjectInHTMLChildren` is disabled</span>
+      </Trans>,
+    );
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,6 @@
 {
+  "exclude": ["example/**/*"],
+
   "compilerOptions": {
     "module": "commonjs",
     "target": "es5",


### PR DESCRIPTION
fixes #1730.

This is technically a breaking change since it change `Trans` and `TransProps` type parameters, however I don't think usually people explicit them when using the component... but who knows 🤷.

-----

I tried to replicate a type parameter structure similar to the `TFunction`, 
however, looks like that using a single `TOpt` type parameter doesn't pass the property values (like `context`) down to `TransProps` properly so `ParseKeys` is not aware of the context value.

The only alternative is to add a new type parameter and pass it down the chain, which is basically what @stefan-schweiger proposed in the above linked issue (Thanks 🙏). 

----

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
