### PR TITLE
use the commented out async code

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -24,35 +24,18 @@ export class ReportNamespaces {
 }
 
 export function composeInitialProps(ForComponent) {
-  return (ctx) =>
-    new Promise((resolve) => {
-      const i18nInitialProps = getInitialProps();
+  return async (ctx) => {
+    const componentsInitialProps = ForComponent.getInitialProps
+      ? await ForComponent.getInitialProps(ctx)
+      : {};
 
-      if (ForComponent.getInitialProps) {
-        ForComponent.getInitialProps(ctx).then((componentsInitialProps) => {
-          resolve({
-            ...componentsInitialProps,
-            ...i18nInitialProps,
-          });
-        });
-      } else {
-        resolve(i18nInitialProps);
-      }
-    });
-  // Avoid async for now - so we do not need to pull in regenerator
+    const i18nInitialProps = getInitialProps();
 
-  // return async ctx => {
-  //   const componentsInitialProps = ForComponent.getInitialProps
-  //     ? await ForComponent.getInitialProps(ctx)
-  //     : {};
-
-  //   const i18nInitialProps = getInitialProps();
-
-  //   return {
-  //     ...componentsInitialProps,
-  //     ...i18nInitialProps,
-  //   };
-  // };
+    return {
+      ...componentsInitialProps,
+      ...i18nInitialProps,
+    };
+  };
 }
 
 export function getInitialProps() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

There was some code that was commented out that should be more performant and smaller than the existing code. This was done to avoid pulling in regenerator runtimes in the past but it seems this is no longer an issue and can be used without doing so.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)