### PR TITLE
test(types): fix broken tests

### DIFF
--- a/vitest.workspace.typescript.mts
+++ b/vitest.workspace.typescript.mts
@@ -27,6 +27,17 @@ export default defineWorkspace(
           test: {
             dir: `./${dirPath}`,
             name: workspaceName,
+            alias: {
+              /**
+               * From `vitest` >= 2 imports are resolved even if we are running only typecheck tests.
+               * This will result in:
+               * ```text
+               * Error: Failed to resolve entry for package "react-i18next". The package may have incorrect main/module/exports specified in its package.json.
+               * ```
+               * To avoid a useless build process before running these tests an empty alias to `react-i18next` is added.
+               */
+              'react-i18next': '',
+            },
             typecheck: {
               enabled: true,
               include: [`**/${dirPath}/*.test.{ts,tsx}`],


### PR DESCRIPTION
After #1769 typescript tests are broken:

- PR check actions: https://github.com/i18next/react-i18next/actions/runs/9955337360/job/27502861502
- Ci commit on master: https://github.com/i18next/react-i18next/actions/runs/9955483146/job/27503339706

Applied the same configuration of `i18next` (https://github.com/i18next/i18next/pull/2210)

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
