### PR TITLE
fix: lint-staged prettier command

### DIFF
--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,4 +1,4 @@
 export default {
-  '!*.?(c|m){js,ts}?(x)': ['prettier --write '],
+  '!*.?(c|m){js,ts}?(x)': ['prettier --write --ignore-unknown'],
   '*.?(c|m){js,ts}?(x)': ['prettier --write --ignore-unknown', 'eslint --cache --fix --env-info'],
 };


### PR DESCRIPTION
### Description

Adds the `--ignore-unknown` flag when running Prettier from lint-staged, which was accidentally missing from #1779.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)