### PR TITLE
chore: update babel-plugin-tester to v11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "all-contributors-cli": "^6.26.1",
         "babel-core": "^7.0.0-bridge.0",
         "babel-plugin-macros": "^3.1.0",
-        "babel-plugin-tester": "^10.1.0",
+        "babel-plugin-tester": "^11.0.4",
         "coveralls": "^3.1.1",
         "cpy-cli": "^5.0.0",
         "cross-env": "^7.0.3",
@@ -3498,6 +3498,8 @@
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -3511,6 +3513,8 @@
       "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
       "integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.0.0"
       }
@@ -3520,6 +3524,8 @@
       "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
       "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.1.0",
         "@babel/types": "^7.0.0"
@@ -3530,18 +3536,10 @@
       "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.4.tgz",
       "integrity": "sha512-mSM/iKUk5fDDrEV/e83qY+Cr3I1+Q3qqTuEn++HAWYjEa1+NxZr6CNrcJGf2ZTnq4HoFGC3zaTPZTobCzCFukA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.20.7"
-      }
-    },
-    "node_modules/@types/babel-plugin-tester": {
-      "version": "9.0.10",
-      "resolved": "https://registry.npmjs.org/@types/babel-plugin-tester/-/babel-plugin-tester-9.0.10.tgz",
-      "integrity": "sha512-X+n3nZb8qIZ3a07qt7B5ONfptAZJ6nWLgU5I4U+gm0dRgtcjL+73P2tUkQAJ/iIbRF72BlW/2of5J0qbjlmsBw==",
-      "dev": true,
-      "dependencies": {
-        "@types/babel__core": "*",
-        "@types/prettier": "^2.0.0"
       }
     },
     "node_modules/@types/estree": {
@@ -3641,12 +3639,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
-      "dev": true
-    },
-    "node_modules/@types/prettier": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
-      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
       "dev": true
     },
     "node_modules/@types/prop-types": {
@@ -4655,22 +4647,33 @@
       }
     },
     "node_modules/babel-plugin-tester": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-tester/-/babel-plugin-tester-10.1.0.tgz",
-      "integrity": "sha512-4P2tNaM/Mtg6ytA9YAqmgONnMYqWvdbGDuwRTpIIC9yFZGQrEHoyvDPCx+X1QALAufVb5DKieOPGj5dffiEiNg==",
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-tester/-/babel-plugin-tester-11.0.4.tgz",
+      "integrity": "sha512-cqswtpSPo0e++rZB0l/54EG17LL25l9gLgh59yXfnmNxX+2lZTIOpx2zt4YI9QIClVXc8xf63J6yWwKkzy0jNg==",
       "dev": true,
       "dependencies": {
-        "@types/babel-plugin-tester": "^9.0.0",
+        "core-js": "^3.27.2",
+        "debug": "^4.3.4",
         "lodash.mergewith": "^4.6.2",
-        "prettier": "^2.0.1",
+        "prettier": "^2.8.3",
         "strip-indent": "^3.0.0"
       },
       "engines": {
-        "node": ">=10.13",
-        "npm": ">=6"
+        "node": "^14.20.0 || ^16.16.0 || >=18.5.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.11.6"
+        "@babel/core": ">=7.11.6"
+      }
+    },
+    "node_modules/babel-plugin-tester/node_modules/core-js": {
+      "version": "3.38.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.38.0.tgz",
+      "integrity": "sha512-XPpwqEodRljce9KswjZShh95qJ1URisBeKCjUdq27YdenkslVe7OO0ZJhlYXAChW7OhXaRLl8AAba7IBfoIHug==",
+      "dev": true,
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/babel-plugin-tester/node_modules/prettier": {
@@ -14483,6 +14486,8 @@
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -14496,6 +14501,8 @@
       "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
       "integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -14505,6 +14512,8 @@
       "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
       "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "@babel/parser": "^7.1.0",
         "@babel/types": "^7.0.0"
@@ -14515,18 +14524,10 @@
       "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.4.tgz",
       "integrity": "sha512-mSM/iKUk5fDDrEV/e83qY+Cr3I1+Q3qqTuEn++HAWYjEa1+NxZr6CNrcJGf2ZTnq4HoFGC3zaTPZTobCzCFukA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "@babel/types": "^7.20.7"
-      }
-    },
-    "@types/babel-plugin-tester": {
-      "version": "9.0.10",
-      "resolved": "https://registry.npmjs.org/@types/babel-plugin-tester/-/babel-plugin-tester-9.0.10.tgz",
-      "integrity": "sha512-X+n3nZb8qIZ3a07qt7B5ONfptAZJ6nWLgU5I4U+gm0dRgtcjL+73P2tUkQAJ/iIbRF72BlW/2of5J0qbjlmsBw==",
-      "dev": true,
-      "requires": {
-        "@types/babel__core": "*",
-        "@types/prettier": "^2.0.0"
       }
     },
     "@types/estree": {
@@ -14619,12 +14620,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
-      "dev": true
-    },
-    "@types/prettier": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
-      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
       "dev": true
     },
     "@types/prop-types": {
@@ -15373,17 +15368,24 @@
       }
     },
     "babel-plugin-tester": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-tester/-/babel-plugin-tester-10.1.0.tgz",
-      "integrity": "sha512-4P2tNaM/Mtg6ytA9YAqmgONnMYqWvdbGDuwRTpIIC9yFZGQrEHoyvDPCx+X1QALAufVb5DKieOPGj5dffiEiNg==",
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-tester/-/babel-plugin-tester-11.0.4.tgz",
+      "integrity": "sha512-cqswtpSPo0e++rZB0l/54EG17LL25l9gLgh59yXfnmNxX+2lZTIOpx2zt4YI9QIClVXc8xf63J6yWwKkzy0jNg==",
       "dev": true,
       "requires": {
-        "@types/babel-plugin-tester": "^9.0.0",
+        "core-js": "^3.27.2",
+        "debug": "^4.3.4",
         "lodash.mergewith": "^4.6.2",
-        "prettier": "^2.0.1",
+        "prettier": "^2.8.3",
         "strip-indent": "^3.0.0"
       },
       "dependencies": {
+        "core-js": {
+          "version": "3.38.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.38.0.tgz",
+          "integrity": "sha512-XPpwqEodRljce9KswjZShh95qJ1URisBeKCjUdq27YdenkslVe7OO0ZJhlYXAChW7OhXaRLl8AAba7IBfoIHug==",
+          "dev": true
+        },
         "prettier": {
           "version": "2.8.8",
           "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "all-contributors-cli": "^6.26.1",
     "babel-core": "^7.0.0-bridge.0",
     "babel-plugin-macros": "^3.1.0",
-    "babel-plugin-tester": "^10.1.0",
+    "babel-plugin-tester": "^11.0.4",
     "coveralls": "^3.1.1",
     "cpy-cli": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/test/__snapshots__/icu.macro.spec.js.snap
+++ b/test/__snapshots__/icu.macro.spec.js.snap
@@ -2,9 +2,11 @@
 
 exports[`macros > 1. macros > 1. macros 1`] = `
 "
-import { Trans } from '../icu.macro'
+
+import { Trans } from '../../../icu.macro'
 
 const x = <Trans>Welcome, { name }!</Trans>
+    
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -18,15 +20,16 @@ const x = (
     }}
   />
 );
-
 "
 `;
 
 exports[`macros > 2. macros > 2. macros 1`] = `
 "
-import { Trans } from '../icu.macro'
+
+import { Trans } from '../../../icu.macro'
 
 const x = <Trans>Welcome, <strong>{ name }</strong>!</Trans>
+    
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -40,16 +43,17 @@ const x = (
     }}
   />
 );
-
 "
 `;
 
 exports[`macros > 3. macros > 3. macros 1`] = `
 "
-import { Trans } from '../icu.macro'
+
+import { Trans } from '../../../icu.macro'
 import { useTranslation } from 'react-i18next'
 
 const x = <Trans>Trainers: { trainersCount, number }</Trans>
+    
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -63,15 +67,16 @@ const x = (
     }}
   />
 );
-
 "
 `;
 
 exports[`macros > 4. macros > 4. macros 1`] = `
 "
-import { Trans } from '../icu.macro'
+
+import { Trans } from '../../../icu.macro'
 
 const x = <Trans>Trainers: <strong>{ trainersCount, number }</strong>!</Trans>
+    
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -85,15 +90,16 @@ const x = (
     }}
   />
 );
-
 "
 `;
 
 exports[`macros > 5. macros > 5. macros 1`] = `
 "
-import { Trans } from '../icu.macro'
+
+import { Trans } from '../../../icu.macro'
 
 const x = <Trans>Caught on { catchDate, date, short }</Trans>
+    
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -107,15 +113,16 @@ const x = (
     }}
   />
 );
-
 "
 `;
 
 exports[`macros > 6. macros > 6. macros 1`] = `
 "
-import { Trans } from '../icu.macro'
+
+import { Trans } from '../../../icu.macro'
 
 const x = <Trans>Caught on <strong>{ catchDate, date, short }</strong>!</Trans>
+    
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -129,15 +136,16 @@ const x = (
     }}
   />
 );
-
 "
 `;
 
 exports[`macros > 7. macros > 7. macros 1`] = `
 "
-import { Trans } from '../icu.macro'
+
+import { Trans } from '../../../icu.macro'
 
 const x = <Trans defaults="Trainers: { trainersCount, number }" />
+    
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -151,15 +159,16 @@ const x = (
     }}
   />
 );
-
 "
 `;
 
 exports[`macros > 8. macros > 8. macros 1`] = `
 "
-import { Trans } from '../icu.macro'
+
+import { Trans } from '../../../icu.macro'
 
 const x = <Trans i18nKey="trainersWithDefaults" defaults="Trainers: <strong>{ trainersCount, number }</strong>!" />
+    
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -174,15 +183,16 @@ const x = (
     }}
   />
 );
-
 "
 `;
 
 exports[`macros > 9. macros > 9. macros 1`] = `
 "
-import { Trans } from '../icu.macro'
+
+import { Trans } from '../../../icu.macro'
 
 const x = <Trans i18nKey="caughtWithDefaults" defaults="Caught on { catchDate, date, short }" />
+    
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -197,15 +207,16 @@ const x = (
     }}
   />
 );
-
 "
 `;
 
 exports[`macros > 10. macros > 10. macros 1`] = `
 "
-import { Trans } from '../icu.macro'
+
+import { Trans } from '../../../icu.macro'
 
 const x = <Trans defaults="Caught on <strong>{ catchDate, date, short }</strong>!" />
+    
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -219,16 +230,17 @@ const x = (
     }}
   />
 );
-
 "
 `;
 
 exports[`macros > 11. macros > 11. macros 1`] = `
 "
-import { Trans } from '../icu.macro'
+
+import { Trans } from '../../../icu.macro'
 const Link = ({to, children}) => (<a href={to}>{children}</a>)
 
 const x = <Trans defaults="Caught on <Link to='/dest'>{ catchDate, date, short }</Link>!" values={{catchDate: Date.now()}}>This should be overridden by defaults</Trans>
+    
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -243,15 +255,16 @@ const x = (
     components={[<Link to="/dest">{catchDate}</Link>]}
   />
 );
-
 "
 `;
 
 exports[`macros > 12. macros > 12. macros 1`] = `
 "
-import { Trans } from '../icu.macro'
+
+import { Trans } from '../../../icu.macro'
 
 const x = <Trans i18nKey="trainersWithDefaults" values={{trainersCount}} defaults="Trainers: <strong>{ trainersCount, number }</strong>!" components={[]} />
+    
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -266,13 +279,13 @@ const x = (
     components={[]}
   />
 );
-
 "
 `;
 
 exports[`macros > 13. macros > 13. macros 1`] = `
 "
-import { Select } from '../icu.macro'
+
+import { Select } from '../../../icu.macro'
 
 const x = <Select
   i18nKey="selectExample"
@@ -281,6 +294,7 @@ const x = <Select
   female="She avoids bugs."
   other="They avoid bugs."
 />
+    
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -295,13 +309,13 @@ const x = (
     }}
   />
 );
-
 "
 `;
 
 exports[`macros > 14. macros > 14. macros 1`] = `
 "
-import { Select } from '../icu.macro'
+
+import { Select } from '../../../icu.macro'
 
 const x = <Select
   switch={gender}
@@ -309,6 +323,7 @@ const x = <Select
   female={<Trans><strong>She</strong> avoids bugs.</Trans>}
   other={<Trans><strong>They</strong> avoid bugs.</Trans>}
 />
+    
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -322,13 +337,13 @@ const x = (
     }}
   />
 );
-
 "
 `;
 
 exports[`macros > 15. macros > 15. macros 1`] = `
 "
-import { Plural } from '../icu.macro'
+
+import { Plural } from '../../../icu.macro'
 
 const x = <Plural
   count={itemsCount1}
@@ -336,6 +351,7 @@ const x = <Plural
   one="There is # item."
   other="There are # items."
 />
+    
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -349,13 +365,13 @@ const x = (
     }}
   />
 );
-
 "
 `;
 
 exports[`macros > 16. macros > 16. macros 1`] = `
 "
-import { Plural } from '../icu.macro'
+
+import { Plural } from '../../../icu.macro'
 
 const x = <Plural
   i18nKey="testKey"
@@ -364,6 +380,7 @@ const x = <Plural
   one={<Trans>There is <strong>#</strong> item.</Trans>}
   other={<Trans>There are <strong>#</strong> items.</Trans>}
 />
+    
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -378,13 +395,13 @@ const x = (
     }}
   />
 );
-
 "
 `;
 
 exports[`macros > 17. macros > 17. macros 1`] = `
 "
-import { Plural } from '../icu.macro'
+
+import { Plural } from '../../../icu.macro'
 
 const x = <Plural
   i18nKey="testKey"
@@ -394,6 +411,7 @@ const x = <Plural
   one={<Trans>There is <strong>#</strong> item on the <i>{location}</i>.</Trans>}
   other={<Trans>There are <strong>#</strong> items on the <i>{location}</i>.</Trans>}
 />
+    
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -416,13 +434,13 @@ const x = (
     }}
   />
 );
-
 "
 `;
 
 exports[`macros > 18. macros > 18. macros 1`] = `
 "
-import { SelectOrdinal } from '../icu.macro'
+
+import { SelectOrdinal } from '../../../icu.macro'
 
 const x = <SelectOrdinal
   count={position}
@@ -434,6 +452,7 @@ const x = <SelectOrdinal
   other="You are #th in line"
   $7="You are in the lucky #th place in line"
 />
+    
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -447,13 +466,13 @@ const x = (
     }}
   />
 );
-
 "
 `;
 
 exports[`macros > 19. macros > 19. macros 1`] = `
 "
-import { SelectOrdinal } from '../icu.macro'
+
+import { SelectOrdinal } from '../../../icu.macro'
 
 const x = <SelectOrdinal
   i18nKey="testKey"
@@ -464,6 +483,7 @@ const x = <SelectOrdinal
   other={<Trans>You are <strong>#th in line</strong></Trans>}
   $0={<Trans>You are <strong>#th in line</strong></Trans>}
 />
+    
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -484,15 +504,15 @@ const x = (
     }}
   />
 );
-
 "
 `;
 
 exports[`macros > 20. macros > 20. macros 1`] = `
 "
+
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Plural, Select, SelectOrdinal, Trans } from '../icu.macro'
+import { Plural, Select, SelectOrdinal, Trans } from '../../../icu.macro'
 const Link = ({to, children}) => (<a href={to}>{children}</a>)
 
 export default function TestPage({count = 1}) {
@@ -596,6 +616,7 @@ export default function TestPage({count = 1}) {
     </>
   )
 }
+    
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -733,14 +754,14 @@ export default function TestPage({ count = 1 }) {
     </>
   );
 }
-
 "
 `;
 
 exports[`macros > 21. macros > 21. macros 1`] = `
 "
+
 import React from "react"
-import { Trans, number, date, time, plural, select, selectOrdinal } from "../icu.macro";
+import { Trans, number, date, time, plural, select, selectOrdinal } from "../../../icu.macro";
 
 function Component({ children, style }) {
   return <div style={style}>{children}</div>
@@ -762,6 +783,7 @@ const x = (
      </Component>}} \`}
   </Trans>
 );
+    
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -797,15 +819,16 @@ const x = (
     }}
   />
 );
-
 "
 `;
 
 exports[`macros > 22. macros > 22. macros 1`] = `
 "
-import { Trans } from "../icu.macro";
+
+import { Trans } from "../../../icu.macro";
 
 const x = <Trans>Welcome, &quot;{ name }&quot;!</Trans>
+    
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -819,829 +842,5 @@ const x = (
     }}
   />
 );
-
-"
-`;
-
-exports[`unknown plugin > 1. unknown plugin > 1. unknown plugin 1`] = `
-"
-import { Trans } from '../icu.macro'
-
-const x = <Trans>Welcome, { name }!</Trans>
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-import { Trans } from 'react-i18next';
-const x = (
-  <Trans
-    defaults="Welcome, {name}!"
-    components={[]}
-    values={{
-      name,
-    }}
-  />
-);
-
-"
-`;
-
-exports[`unknown plugin > 2. unknown plugin > 2. unknown plugin 1`] = `
-"
-import { Trans } from '../icu.macro'
-
-const x = <Trans>Welcome, <strong>{ name }</strong>!</Trans>
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-import { Trans } from 'react-i18next';
-const x = (
-  <Trans
-    defaults="Welcome, <0>{name}</0>!"
-    components={[<strong>{name}</strong>]}
-    values={{
-      name,
-    }}
-  />
-);
-
-"
-`;
-
-exports[`unknown plugin > 3. unknown plugin > 3. unknown plugin 1`] = `
-"
-import { Trans } from '../icu.macro'
-import { useTranslation } from 'react-i18next'
-
-const x = <Trans>Trainers: { trainersCount, number }</Trans>
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-import { useTranslation, Trans } from 'react-i18next';
-const x = (
-  <Trans
-    defaults="Trainers: {trainersCount, number}"
-    components={[]}
-    values={{
-      trainersCount,
-    }}
-  />
-);
-
-"
-`;
-
-exports[`unknown plugin > 4. unknown plugin > 4. unknown plugin 1`] = `
-"
-import { Trans } from '../icu.macro'
-
-const x = <Trans>Trainers: <strong>{ trainersCount, number }</strong>!</Trans>
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-import { Trans } from 'react-i18next';
-const x = (
-  <Trans
-    defaults="Trainers: <0>{trainersCount, number}</0>!"
-    components={[<strong>{trainersCount}</strong>]}
-    values={{
-      trainersCount,
-    }}
-  />
-);
-
-"
-`;
-
-exports[`unknown plugin > 5. unknown plugin > 5. unknown plugin 1`] = `
-"
-import { Trans } from '../icu.macro'
-
-const x = <Trans>Caught on { catchDate, date, short }</Trans>
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-import { Trans } from 'react-i18next';
-const x = (
-  <Trans
-    defaults="Caught on {catchDate, date, short}"
-    components={[]}
-    values={{
-      catchDate,
-    }}
-  />
-);
-
-"
-`;
-
-exports[`unknown plugin > 6. unknown plugin > 6. unknown plugin 1`] = `
-"
-import { Trans } from '../icu.macro'
-
-const x = <Trans>Caught on <strong>{ catchDate, date, short }</strong>!</Trans>
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-import { Trans } from 'react-i18next';
-const x = (
-  <Trans
-    defaults="Caught on <0>{catchDate, date, short}</0>!"
-    components={[<strong>{catchDate}</strong>]}
-    values={{
-      catchDate,
-    }}
-  />
-);
-
-"
-`;
-
-exports[`unknown plugin > 7. unknown plugin > 7. unknown plugin 1`] = `
-"
-import { Trans } from '../icu.macro'
-
-const x = <Trans defaults="Trainers: { trainersCount, number }" />
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-import { Trans } from 'react-i18next';
-const x = (
-  <Trans
-    defaults="Trainers: {trainersCount, number}"
-    components={[]}
-    values={{
-      trainersCount,
-    }}
-  />
-);
-
-"
-`;
-
-exports[`unknown plugin > 8. unknown plugin > 8. unknown plugin 1`] = `
-"
-import { Trans } from '../icu.macro'
-
-const x = <Trans i18nKey="trainersWithDefaults" defaults="Trainers: <strong>{ trainersCount, number }</strong>!" />
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-import { Trans } from 'react-i18next';
-const x = (
-  <Trans
-    i18nKey="trainersWithDefaults"
-    defaults="Trainers: <0>{trainersCount, number}</0>!"
-    components={[<strong>{trainersCount}</strong>]}
-    values={{
-      trainersCount,
-    }}
-  />
-);
-
-"
-`;
-
-exports[`unknown plugin > 9. unknown plugin > 9. unknown plugin 1`] = `
-"
-import { Trans } from '../icu.macro'
-
-const x = <Trans i18nKey="caughtWithDefaults" defaults="Caught on { catchDate, date, short }" />
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-import { Trans } from 'react-i18next';
-const x = (
-  <Trans
-    i18nKey="caughtWithDefaults"
-    defaults="Caught on {catchDate, date, short}"
-    components={[]}
-    values={{
-      catchDate,
-    }}
-  />
-);
-
-"
-`;
-
-exports[`unknown plugin > 10. unknown plugin > 10. unknown plugin 1`] = `
-"
-import { Trans } from '../icu.macro'
-
-const x = <Trans defaults="Caught on <strong>{ catchDate, date, short }</strong>!" />
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-import { Trans } from 'react-i18next';
-const x = (
-  <Trans
-    defaults="Caught on <0>{catchDate, date, short}</0>!"
-    components={[<strong>{catchDate}</strong>]}
-    values={{
-      catchDate,
-    }}
-  />
-);
-
-"
-`;
-
-exports[`unknown plugin > 11. unknown plugin > 11. unknown plugin 1`] = `
-"
-import { Trans } from '../icu.macro'
-const Link = ({to, children}) => (<a href={to}>{children}</a>)
-
-const x = <Trans defaults="Caught on <Link to='/dest'>{ catchDate, date, short }</Link>!" values={{catchDate: Date.now()}}>This should be overridden by defaults</Trans>
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-import { Trans } from 'react-i18next';
-const Link = ({ to, children }) => <a href={to}>{children}</a>;
-const x = (
-  <Trans
-    values={{
-      catchDate: Date.now(),
-    }}
-    defaults="Caught on <0>{catchDate, date, short}</0>!"
-    components={[<Link to="/dest">{catchDate}</Link>]}
-  />
-);
-
-"
-`;
-
-exports[`unknown plugin > 12. unknown plugin > 12. unknown plugin 1`] = `
-"
-import { Trans } from '../icu.macro'
-
-const x = <Trans i18nKey="trainersWithDefaults" values={{trainersCount}} defaults="Trainers: <strong>{ trainersCount, number }</strong>!" components={[]} />
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-import { Trans } from 'react-i18next';
-const x = (
-  <Trans
-    i18nKey="trainersWithDefaults"
-    values={{
-      trainersCount,
-    }}
-    defaults="Trainers: <strong>{ trainersCount, number }</strong>!"
-    components={[]}
-  />
-);
-
-"
-`;
-
-exports[`unknown plugin > 13. unknown plugin > 13. unknown plugin 1`] = `
-"
-import { Select } from '../icu.macro'
-
-const x = <Select
-  i18nKey="selectExample"
-  switch={gender}
-  male="He avoids bugs."
-  female="She avoids bugs."
-  other="They avoid bugs."
-/>
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-import { Trans } from 'react-i18next';
-const x = (
-  <Trans
-    i18nKey="selectExample"
-    defaults="{gender, select,  male {He avoids bugs.} female {She avoids bugs.} other {They avoid bugs.}}"
-    components={[]}
-    values={{
-      gender,
-    }}
-  />
-);
-
-"
-`;
-
-exports[`unknown plugin > 14. unknown plugin > 14. unknown plugin 1`] = `
-"
-import { Select } from '../icu.macro'
-
-const x = <Select
-  switch={gender}
-  male={<Trans><strong>He</strong> avoids bugs.</Trans>}
-  female={<Trans><strong>She</strong> avoids bugs.</Trans>}
-  other={<Trans><strong>They</strong> avoid bugs.</Trans>}
-/>
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-import { Trans } from 'react-i18next';
-const x = (
-  <Trans
-    defaults="{gender, select,  male {<0>He</0> avoids bugs.} female {<1>She</1> avoids bugs.} other {<2>They</2> avoid bugs.}}"
-    components={[<strong>He</strong>, <strong>She</strong>, <strong>They</strong>]}
-    values={{
-      gender,
-    }}
-  />
-);
-
-"
-`;
-
-exports[`unknown plugin > 15. unknown plugin > 15. unknown plugin 1`] = `
-"
-import { Plural } from '../icu.macro'
-
-const x = <Plural
-  count={itemsCount1}
-  $0="There are no items."
-  one="There is # item."
-  other="There are # items."
-/>
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-import { Trans } from 'react-i18next';
-const x = (
-  <Trans
-    defaults="{itemsCount1, plural,  =0 {There are no items.} one {There is # item.} other {There are # items.}}"
-    components={[]}
-    values={{
-      itemsCount1,
-    }}
-  />
-);
-
-"
-`;
-
-exports[`unknown plugin > 16. unknown plugin > 16. unknown plugin 1`] = `
-"
-import { Plural } from '../icu.macro'
-
-const x = <Plural
-  i18nKey="testKey"
-  count={itemsCount3}
-  $0={<Trans>There is <strong>no</strong> item.</Trans>}
-  one={<Trans>There is <strong>#</strong> item.</Trans>}
-  other={<Trans>There are <strong>#</strong> items.</Trans>}
-/>
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-import { Trans } from 'react-i18next';
-const x = (
-  <Trans
-    i18nKey="testKey"
-    defaults="{itemsCount3, plural,  =0 {There is <0>no</0> item.} one {There is <1>#</1> item.} other {There are <2>#</2> items.}}"
-    components={[<strong>no</strong>, <strong>#</strong>, <strong>#</strong>]}
-    values={{
-      itemsCount3,
-    }}
-  />
-);
-
-"
-`;
-
-exports[`unknown plugin > 17. unknown plugin > 17. unknown plugin 1`] = `
-"
-import { Plural } from '../icu.macro'
-
-const x = <Plural
-  i18nKey="testKey"
-  count={itemsCount3}
-  values={{location: 'table'}}
-  $0={<Trans>There is <strong>no</strong> item on the <i>{location}</i>.</Trans>}
-  one={<Trans>There is <strong>#</strong> item on the <i>{location}</i>.</Trans>}
-  other={<Trans>There are <strong>#</strong> items on the <i>{location}</i>.</Trans>}
-/>
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-import { Trans } from 'react-i18next';
-const x = (
-  <Trans
-    i18nKey="testKey"
-    defaults="{itemsCount3, plural,  =0 {There is <0>no</0> item on the <1>{location}</1>.} one {There is <2>#</2> item on the <3>{location}</3>.} other {There are <4>#</4> items on the <5>{location}</5>.}}"
-    components={[
-      <strong>no</strong>,
-      <i>{location}</i>,
-      <strong>#</strong>,
-      <i>{location}</i>,
-      <strong>#</strong>,
-      <i>{location}</i>,
-    ]}
-    values={{
-      itemsCount3,
-      location: 'table',
-    }}
-  />
-);
-
-"
-`;
-
-exports[`unknown plugin > 18. unknown plugin > 18. unknown plugin 1`] = `
-"
-import { SelectOrdinal } from '../icu.macro'
-
-const x = <SelectOrdinal
-  count={position}
-  zero="You are #th in line"
-  one="You are #st in line"
-  two="You are #nd in line"
-  few="You are #rd in line"
-  many="You are #th in line"
-  other="You are #th in line"
-  $7="You are in the lucky #th place in line"
-/>
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-import { Trans } from 'react-i18next';
-const x = (
-  <Trans
-    defaults="{position, selectordinal,  zero {You are #th in line} one {You are #st in line} two {You are #nd in line} few {You are #rd in line} many {You are #th in line} other {You are #th in line} =7 {You are in the lucky #th place in line}}"
-    components={[]}
-    values={{
-      position,
-    }}
-  />
-);
-
-"
-`;
-
-exports[`unknown plugin > 19. unknown plugin > 19. unknown plugin 1`] = `
-"
-import { SelectOrdinal } from '../icu.macro'
-
-const x = <SelectOrdinal
-  i18nKey="testKey"
-  count={position}
-  one={<Trans>You are <strong>#st in line</strong></Trans>}
-  two={<Trans>You are <strong>#nd in line</strong></Trans>}
-  few={<Trans>You are <strong>#rd in line</strong></Trans>}
-  other={<Trans>You are <strong>#th in line</strong></Trans>}
-  $0={<Trans>You are <strong>#th in line</strong></Trans>}
-/>
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-import { Trans } from 'react-i18next';
-const x = (
-  <Trans
-    i18nKey="testKey"
-    defaults="{position, selectordinal,  one {You are <0>#st in line</0>} two {You are <1>#nd in line</1>} few {You are <2>#rd in line</2>} other {You are <3>#th in line</3>} =0 {You are <4>#th in line</4>}}"
-    components={[
-      <strong>#st in line</strong>,
-      <strong>#nd in line</strong>,
-      <strong>#rd in line</strong>,
-      <strong>#th in line</strong>,
-      <strong>#th in line</strong>,
-    ]}
-    values={{
-      position,
-    }}
-  />
-);
-
-"
-`;
-
-exports[`unknown plugin > 20. unknown plugin > 20. unknown plugin 1`] = `
-"
-import React from 'react'
-import { useTranslation } from 'react-i18next'
-import { Plural, Select, SelectOrdinal, Trans } from '../icu.macro'
-const Link = ({to, children}) => (<a href={to}>{children}</a>)
-
-export default function TestPage({count = 1}) {
-  const [t] = useTranslation()
-  const catchDate = Date.now()
-  const completion = 0.75
-  const gender = Math.random() < 0.5 ? 'female' : 'male'
-  return (
-    <>
-      {t('sample.text', 'Some sample text with {word} {gender} {count, number} {catchDate, date} {completion, number, percent}', {word: 'interpolation', gender, count, catchDate, completion})}
-      <Plural i18nKey="plural"
-        count={count}
-        values={{linkPath: "/item/" + count}}
-        $0={<Trans><Link to='/cart'>Your cart</Link> is <strong>empty</strong>.</Trans>}
-        one={<Trans>You have <strong># item</strong> in <Link to='/cart'>your cart</Link>.</Trans>}
-        other={<Trans>You have <strong># items</strong> in <Link to='/cart'>your cart</Link>.</Trans>}
-      />
-      <Select
-        i18nKey="select"
-        switch={gender}
-        female={<Trans>These are <Link to='/items'>her items</Link></Trans>}
-        male={<Trans>These are <Link to='/items'>his items</Link></Trans>}
-        other={<Trans>These are <Link to='/items'>their items</Link></Trans>}
-      />
-      <SelectOrdinal i18nKey="ordinal"
-        count={itemIndex+1}
-        values={{linkPath: "/item/" + itemIndex}}
-        one={<Trans>Your <Link to={linkPath}><strong>#st</strong> item</Link></Trans>}
-        two={<Trans>Your <Link to={linkPath}><strong>#nd</strong> item</Link></Trans>}
-        few={<Trans>Your <Link to={linkPath}><strong>#rd</strong> item</Link></Trans>}
-        other={<Trans>Your <Link to={linkPath}><strong>#th</strong> item</Link></Trans>}
-      />
-      <Trans i18nKey="percent" defaults="You&apos;ve completed <Link to='/tasks'>{completion, number, percent} of your tasks</Link>."/>
-      <Trans i18nKey="date" defaults="Caught on <Link to='/dest'>{ catchDate, date, short }</Link>!"/>
-      <SelectOrdinal
-        i18nKey="ordinal.prettier"
-        count={count}
-        values={{ linkPath: \`/item/\${count}\`, type: 'item', prop }}
-        one={
-          <Trans>
-            Your{' '}
-            <Link to={linkPath}>
-              <strong>#st</strong> {type}
-            </Link>
-          </Trans>
-        }
-        two={
-          <Trans>
-            Your{' '}
-            <Link to={linkPath}>
-              <strong>#nd</strong> {type}
-            </Link>
-          </Trans>
-        }
-        few={
-          <Trans>
-            Your{' '}
-            <Link to={linkPath}>
-              <strong>#rd</strong> {type}
-            </Link>
-          </Trans>
-        }
-        other={
-          <Trans>
-            Your{' '}
-            <Link to={linkPath}>
-              <strong>#th</strong> {type}
-            </Link>
-          </Trans>
-        }
-      />
-      <Select
-        i18nKey="select.expr.prettier"
-        switch={\`\${gender}Person\`}
-        values={{ linkPath: \`/users/\${number}\`, type: 'bugs' }}
-        malePerson={
-          <Trans>
-            <Link to={linkPath}>
-              <strong>He</strong>
-            </Link>{' '}
-            avoids {type}.
-          </Trans>
-        }
-        femalePerson={
-          <Trans>
-            <Link to={linkPath}>
-              <strong>She</strong>
-            </Link>{' '}
-            avoids {type}.
-          </Trans>
-        }
-        other={
-          <Trans>
-            <Link to={linkPath}>
-              <strong>They</strong>
-            </Link>{' '}
-            avoid {type}.
-          </Trans>
-        }
-      />
-    </>
-  )
-}
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-import React from 'react';
-import { useTranslation, Trans } from 'react-i18next';
-const Link = ({ to, children }) => <a href={to}>{children}</a>;
-export default function TestPage({ count = 1 }) {
-  const [t] = useTranslation();
-  const catchDate = Date.now();
-  const completion = 0.75;
-  const gender = Math.random() < 0.5 ? 'female' : 'male';
-  return (
-    <>
-      {t(
-        'sample.text',
-        'Some sample text with {word} {gender} {count, number} {catchDate, date} {completion, number, percent}',
-        {
-          word: 'interpolation',
-          gender,
-          count,
-          catchDate,
-          completion,
-        },
-      )}
-      <Trans
-        i18nKey="plural"
-        count={count}
-        defaults="{count, plural,  =0 {<0>Your cart</0> is <1>empty</1>.} one {You have <2># item</2> in <3>your cart</3>.} other {You have <4># items</4> in <5>your cart</5>.}}"
-        components={[
-          <Link to="/cart">Your cart</Link>,
-          <strong>empty</strong>,
-          <strong># item</strong>,
-          <Link to="/cart">your cart</Link>,
-          <strong># items</strong>,
-          <Link to="/cart">your cart</Link>,
-        ]}
-        values={{
-          linkPath: '/item/' + count,
-        }}
-      />
-      <Trans
-        i18nKey="select"
-        defaults="{gender, select,  female {These are <0>her items</0>} male {These are <1>his items</1>} other {These are <2>their items</2>}}"
-        components={[
-          <Link to="/items">her items</Link>,
-          <Link to="/items">his items</Link>,
-          <Link to="/items">their items</Link>,
-        ]}
-        values={{
-          gender,
-        }}
-      />
-      <Trans
-        i18nKey="ordinal"
-        count={itemIndex + 1}
-        defaults="{count, selectordinal,  one {Your <0><0>#st</0> item</0>} two {Your <1><0>#nd</0> item</1>} few {Your <2><0>#rd</0> item</2>} other {Your <3><0>#th</0> item</3>}}"
-        components={[
-          <Link to={linkPath}>
-            <strong>#st</strong> item
-          </Link>,
-          <Link to={linkPath}>
-            <strong>#nd</strong> item
-          </Link>,
-          <Link to={linkPath}>
-            <strong>#rd</strong> item
-          </Link>,
-          <Link to={linkPath}>
-            <strong>#th</strong> item
-          </Link>,
-        ]}
-        values={{
-          linkPath: '/item/' + itemIndex,
-        }}
-      />
-      <Trans
-        i18nKey="percent"
-        defaults="You've completed <0>{completion, number, percent} of your tasks</0>."
-        components={[<Link to="/tasks">{completion} of your tasks</Link>]}
-        values={{
-          completion,
-        }}
-      />
-      <Trans
-        i18nKey="date"
-        defaults="Caught on <0>{catchDate, date, short}</0>!"
-        components={[<Link to="/dest">{catchDate}</Link>]}
-        values={{
-          catchDate,
-        }}
-      />
-      <Trans
-        i18nKey="ordinal.prettier"
-        count={count}
-        defaults="{count, selectordinal,  one {Your <0><0>#st</0> {type}</0>} two {Your <1><0>#nd</0> {type}</1>} few {Your <2><0>#rd</0> {type}</2>} other {Your <3><0>#th</0> {type}</3>}}"
-        components={[
-          <Link to={linkPath}>
-            <strong>#st</strong> {type}
-          </Link>,
-          <Link to={linkPath}>
-            <strong>#nd</strong> {type}
-          </Link>,
-          <Link to={linkPath}>
-            <strong>#rd</strong> {type}
-          </Link>,
-          <Link to={linkPath}>
-            <strong>#th</strong> {type}
-          </Link>,
-        ]}
-        values={{
-          linkPath: \`/item/\${count}\`,
-          type: 'item',
-          prop,
-        }}
-      />
-      <Trans
-        i18nKey="select.expr.prettier"
-        defaults="{selectKey, select,  malePerson {<0><0>He</0></0> avoids {type}.} femalePerson {<1><0>She</0></1> avoids {type}.} other {<2><0>They</0></2> avoid {type}.}}"
-        components={[
-          <Link to={linkPath}>
-            <strong>He</strong>
-          </Link>,
-          <Link to={linkPath}>
-            <strong>She</strong>
-          </Link>,
-          <Link to={linkPath}>
-            <strong>They</strong>
-          </Link>,
-        ]}
-        values={{
-          selectKey: \`\${gender}Person\`,
-          linkPath: \`/users/\${number}\`,
-          type: 'bugs',
-        }}
-      />
-    </>
-  );
-}
-
-"
-`;
-
-exports[`unknown plugin > 21. unknown plugin > 21. unknown plugin 1`] = `
-"
-import React from "react"
-import { Trans, number, date, time, plural, select, selectOrdinal } from "../icu.macro";
-
-function Component({ children, style }) {
-  return <div style={style}>{children}</div>
-}
-
-const count = 2;
-const numbers = 34;
-const selectInput = "thing"
-const now = new Date()
-const x = (
-  <Trans i18nKey="key">
-    <strong>exciting!</strong>
-    {plural\`\${count},
-    =0 { hi there \${<strong>friend</strong>} }
-    other { woweee even supports nested \${number\`\${numbers}\`} } \`} and
-    {select\`\${selectInput},
-     thing { another nested \${<Component style={{ color: "red" }}>
-       with regular text and a date: <pre>{date\`\${now}\`}</pre>
-     </Component>}} \`}
-  </Trans>
-);
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-import { Trans, number, date, plural, select } from 'react-i18next';
-import React from 'react';
-function Component({ children, style }) {
-  return <div style={style}>{children}</div>;
-}
-const count = 2;
-const numbers = 34;
-const selectInput = 'thing';
-const now = new Date();
-const x = (
-  <Trans
-    i18nKey="key"
-    defaults="<0>exciting!</0>{count, plural, =0 { hi there <1>friend</1> } other { woweee even supports nested {numbers, number} } } and{selectInput, select, thing { another nested <2>with regular text and a date: <0>{now, date}</0></2>} }"
-    components={[
-      <strong>exciting!</strong>,
-      <strong>friend</strong>,
-      <Component
-        style={{
-          color: 'red',
-        }}
-      >
-        with regular text and a date: <pre>{date\`\${now}\`}</pre>
-      </Component>,
-    ]}
-    values={{
-      count,
-      numbers,
-      selectInput,
-      now,
-    }}
-  />
-);
-
-"
-`;
-
-exports[`unknown plugin > 22. unknown plugin > 22. unknown plugin 1`] = `
-"
-import { Trans } from "../icu.macro";
-
-const x = <Trans>Welcome, &quot;{ name }&quot;!</Trans>
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-import { Trans } from 'react-i18next';
-const x = (
-  <Trans
-    defaults={'Welcome, "{name}"!'}
-    components={[]}
-    values={{
-      name,
-    }}
-  />
-);
-
 "
 `;

--- a/test/icu.macro.spec.js
+++ b/test/icu.macro.spec.js
@@ -19,81 +19,81 @@ pluginTester({
   babelOptions: { filename: __filename, parserOpts: { plugins: ['jsx'] } },
   tests: [
     `
-      import { Trans } from '../icu.macro'
+      import { Trans } from '../../../icu.macro'
 
       const x = <Trans>Welcome, { name }!</Trans>
     `,
 
     `
-      import { Trans } from '../icu.macro'
+      import { Trans } from '../../../icu.macro'
 
       const x = <Trans>Welcome, <strong>{ name }</strong>!</Trans>
     `,
 
     `
-      import { Trans } from '../icu.macro'
+      import { Trans } from '../../../icu.macro'
       import { useTranslation } from 'react-i18next'
 
       const x = <Trans>Trainers: { trainersCount, number }</Trans>
     `,
 
     `
-      import { Trans } from '../icu.macro'
+      import { Trans } from '../../../icu.macro'
 
       const x = <Trans>Trainers: <strong>{ trainersCount, number }</strong>!</Trans>
     `,
 
     `
-      import { Trans } from '../icu.macro'
+      import { Trans } from '../../../icu.macro'
 
       const x = <Trans>Caught on { catchDate, date, short }</Trans>
     `,
 
     `
-      import { Trans } from '../icu.macro'
+      import { Trans } from '../../../icu.macro'
 
       const x = <Trans>Caught on <strong>{ catchDate, date, short }</strong>!</Trans>
     `,
 
     `
-      import { Trans } from '../icu.macro'
+      import { Trans } from '../../../icu.macro'
 
       const x = <Trans defaults="Trainers: { trainersCount, number }" />
     `,
 
     `
-      import { Trans } from '../icu.macro'
+      import { Trans } from '../../../icu.macro'
 
       const x = <Trans i18nKey="trainersWithDefaults" defaults="Trainers: <strong>{ trainersCount, number }</strong>!" />
     `,
 
     `
-      import { Trans } from '../icu.macro'
+      import { Trans } from '../../../icu.macro'
 
       const x = <Trans i18nKey="caughtWithDefaults" defaults="Caught on { catchDate, date, short }" />
     `,
 
     `
-      import { Trans } from '../icu.macro'
+      import { Trans } from '../../../icu.macro'
 
       const x = <Trans defaults="Caught on <strong>{ catchDate, date, short }</strong>!" />
     `,
 
     `
-      import { Trans } from '../icu.macro'
+      import { Trans } from '../../../icu.macro'
       const Link = ({to, children}) => (<a href={to}>{children}</a>)
-      
+
       const x = <Trans defaults="Caught on <Link to='/dest'>{ catchDate, date, short }</Link>!" values={{catchDate: Date.now()}}>This should be overridden by defaults</Trans>
     `,
 
     `
-      import { Trans } from '../icu.macro'
-      
+      import { Trans } from '../../../icu.macro'
+
       const x = <Trans i18nKey="trainersWithDefaults" values={{trainersCount}} defaults="Trainers: <strong>{ trainersCount, number }</strong>!" components={[]} />
     `,
 
     `
-      import { Select } from '../icu.macro'
+      import { Select } from '../../../icu.macro'
 
       const x = <Select
         i18nKey="selectExample"
@@ -105,7 +105,7 @@ pluginTester({
     `,
 
     `
-      import { Select } from '../icu.macro'
+      import { Select } from '../../../icu.macro'
 
       const x = <Select
         switch={gender}
@@ -116,7 +116,7 @@ pluginTester({
     `,
 
     `
-      import { Plural } from '../icu.macro'
+      import { Plural } from '../../../icu.macro'
 
       const x = <Plural
         count={itemsCount1}
@@ -127,7 +127,7 @@ pluginTester({
     `,
 
     `
-      import { Plural } from '../icu.macro'
+      import { Plural } from '../../../icu.macro'
 
       const x = <Plural
         i18nKey="testKey"
@@ -139,7 +139,7 @@ pluginTester({
     `,
 
     `
-      import { Plural } from '../icu.macro'
+      import { Plural } from '../../../icu.macro'
 
       const x = <Plural
         i18nKey="testKey"
@@ -152,7 +152,7 @@ pluginTester({
     `,
 
     `
-      import { SelectOrdinal } from '../icu.macro'
+      import { SelectOrdinal } from '../../../icu.macro'
 
       const x = <SelectOrdinal
         count={position}
@@ -167,7 +167,7 @@ pluginTester({
     `,
 
     `
-      import { SelectOrdinal } from '../icu.macro'
+      import { SelectOrdinal } from '../../../icu.macro'
 
       const x = <SelectOrdinal
         i18nKey="testKey"
@@ -183,9 +183,9 @@ pluginTester({
     `
       import React from 'react'
       import { useTranslation } from 'react-i18next'
-      import { Plural, Select, SelectOrdinal, Trans } from '../icu.macro'
+      import { Plural, Select, SelectOrdinal, Trans } from '../../../icu.macro'
       const Link = ({to, children}) => (<a href={to}>{children}</a>)
-      
+
       export default function TestPage({count = 1}) {
         const [t] = useTranslation()
         const catchDate = Date.now()
@@ -290,7 +290,7 @@ pluginTester({
     `,
     `
       import React from "react"
-      import { Trans, number, date, time, plural, select, selectOrdinal } from "../icu.macro";
+      import { Trans, number, date, time, plural, select, selectOrdinal } from "../../../icu.macro";
 
       function Component({ children, style }) {
         return <div style={style}>{children}</div>
@@ -314,80 +314,80 @@ pluginTester({
       );
     `,
     `
-      import { Trans } from "../icu.macro";
+      import { Trans } from "../../../icu.macro";
 
       const x = <Trans>Welcome, &quot;{ name }&quot;!</Trans>
     `,
     {
       code: `
         import React from "react"
-        import { Trans, number } from "../icu.macro";
+        import { Trans, number } from "../../../icu.macro";
 
         const count = 2;
         const outside = number\`\${count}\`;
       `,
       snapshot: false,
-      error: /"number``" can only be used inside <Trans> in "[^"]+" on line 5/,
+      error: /"number``" can only be used inside <Trans> in "[^"]+" on line 6/,
     },
     {
       code: `
         import React from "react"
-        import { Trans, date } from "../icu.macro";
+        import { Trans, date } from "../../../icu.macro";
 
         const d = new Date;
         const outside = date\`\${d}\`;
       `,
       snapshot: false,
-      error: /"date``" can only be used inside <Trans> in "[^"]+" on line 5/,
+      error: /"date``" can only be used inside <Trans> in "[^"]+" on line 6/,
     },
     {
       code: `
         import React from "react"
-        import { Trans, time } from "../icu.macro";
+        import { Trans, time } from "../../../icu.macro";
 
         const d = new Date;
         const outside = time\`\${d}\`;
       `,
       snapshot: false,
-      error: /"time``" can only be used inside <Trans> in "[^"]+" on line 5/,
+      error: /"time``" can only be used inside <Trans> in "[^"]+" on line 6/,
     },
     {
       code: `
         import React from "react"
-        import { Trans, select } from "../icu.macro";
+        import { Trans, select } from "../../../icu.macro";
 
         const d = "f";
         const outside = select\`\${d}, f { chose f } other { chose something else }\`;
       `,
       snapshot: false,
-      error: /"select``" can only be used inside <Trans> in "[^"]+" on line 5/,
+      error: /"select``" can only be used inside <Trans> in "[^"]+" on line 6/,
     },
     {
       code: `
         import React from "react"
-        import { Trans, selectOrdinal } from "../icu.macro";
+        import { Trans, selectOrdinal } from "../../../icu.macro";
 
         const d = 1;
         const outside = selectOrdinal\`\${d}, =0 { # } other { chose # }\`;
       `,
       snapshot: false,
-      error: /"selectOrdinal``" can only be used inside <Trans> in "[^"]+" on line 5/,
+      error: /"selectOrdinal``" can only be used inside <Trans> in "[^"]+" on line 6/,
     },
     {
       code: `
         import React from "react"
-        import { Trans, plural } from "../icu.macro";
+        import { Trans, plural } from "../../../icu.macro";
 
         const d = 1;
         const outside = plural\`\${d}, =0 { # } other { chose # }\`;
       `,
       snapshot: false,
-      error: /"plural``" can only be used inside <Trans> in "[^"]+" on line 5/,
+      error: /"plural``" can only be used inside <Trans> in "[^"]+" on line 6/,
     },
     {
       code: `
         import React from "react"
-        import { Trans, plural } from "../icu.macro";
+        import { Trans, plural } from "../../../icu.macro";
 
         const d = 1;
         const x = (
@@ -398,12 +398,12 @@ pluginTester({
       `,
       snapshot: false,
       error:
-        /Unsupported tagged template literal "fail", must be one of date, time, number, plural, select, selectOrdinal in "[^"]+" on line 7/,
+        /Unsupported tagged template literal "fail", must be one of date, time, number, plural, select, selectOrdinal in "[^"]+" on line 8/,
     },
     {
       code: `
         import React from "react"
-        import { Trans, date } from "../icu.macro";
+        import { Trans, date } from "../../../icu.macro";
 
         const d = 1;
         const x = (
@@ -413,12 +413,12 @@ pluginTester({
         );
       `,
       snapshot: false,
-      error: /date argument must be interpolated in "date``" in "[^"]+" on line 7/,
+      error: /date argument must be interpolated in "date``" in "[^"]+" on line 8/,
     },
     {
       code: `
         import React from "react"
-        import { Trans, date } from "../icu.macro";
+        import { Trans, date } from "../../../icu.macro";
 
         const tooLate = new Date();
         const x = (
@@ -428,12 +428,12 @@ pluginTester({
         );
       `,
       snapshot: false,
-      error: /date argument must be interpolated at the beginning of "date``" in "[^"]+" on line 7/,
+      error: /date argument must be interpolated at the beginning of "date``" in "[^"]+" on line 8/,
     },
     {
       code: `
         import React from "react"
-        import { Trans, number } from "../icu.macro";
+        import { Trans, number } from "../../../icu.macro";
 
         const tooLate = funcThatReturnsNumberOrUndefined;
         const x = (
@@ -443,7 +443,7 @@ pluginTester({
         );
       `,
       snapshot: false,
-      error: /Must pass a variable, not an expression to "number``" in "[^"]+" on line 7/,
+      error: /Must pass a variable, not an expression to "number``" in "[^"]+" on line 8/,
     },
   ],
 });


### PR DESCRIPTION
### Description

Updates babel-plugin-tester to the latest version (v11). 

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)