### PR TITLE
chore: update eslint-plugin-testing-library to v6

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -65,7 +65,8 @@
         "globalThis": false
       },
       "rules": {
-        "testing-library/no-node-access": ["error", { "allowContainerFirstChild": true }]
+        "testing-library/no-node-access": ["error", { "allowContainerFirstChild": true }],
+        "testing-library/no-manual-cleanup": "off"
       }
     }
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "happy-dom": "^14.12.3",
         "husky": "^9.1.4",
         "i18next": "^23.12.2",
-        "lint-staged": "^15.2.8",
+        "lint-staged": "^15.2.9",
         "mkdirp": "^3.0.1",
         "prettier": "^3.3.3",
         "react": "^18.3.1",
@@ -8973,9 +8973,9 @@
       "dev": true
     },
     "node_modules/lint-staged": {
-      "version": "15.2.8",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.2.8.tgz",
-      "integrity": "sha512-PUWFf2zQzsd9EFU+kM1d7UP+AZDbKFKuj+9JNVTBkhUFhbg4MAt6WfyMMwBfM4lYqd4D2Jwac5iuTu9rVj4zCQ==",
+      "version": "15.2.9",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.2.9.tgz",
+      "integrity": "sha512-BZAt8Lk3sEnxw7tfxM7jeZlPRuT4M68O0/CwZhhaw6eeWu0Lz5eERE3m386InivXB64fp/mDID452h48tvKlRQ==",
       "dev": true,
       "dependencies": {
         "chalk": "~5.3.0",
@@ -18487,9 +18487,9 @@
       "dev": true
     },
     "lint-staged": {
-      "version": "15.2.8",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.2.8.tgz",
-      "integrity": "sha512-PUWFf2zQzsd9EFU+kM1d7UP+AZDbKFKuj+9JNVTBkhUFhbg4MAt6WfyMMwBfM4lYqd4D2Jwac5iuTu9rVj4zCQ==",
+      "version": "15.2.9",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.2.9.tgz",
+      "integrity": "sha512-BZAt8Lk3sEnxw7tfxM7jeZlPRuT4M68O0/CwZhhaw6eeWu0Lz5eERE3m386InivXB64fp/mDID452h48tvKlRQ==",
       "dev": true,
       "requires": {
         "chalk": "~5.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "eslint-plugin-jest-dom": "^5.4.0",
         "eslint-plugin-jsx-a11y": "^6.9.0",
         "eslint-plugin-react": "^7.35.0",
-        "eslint-plugin-testing-library": "^5.11.1",
+        "eslint-plugin-testing-library": "^6.3.0",
         "happy-dom": "^14.12.3",
         "husky": "^9.1.4",
         "i18next": "^23.12.2",
@@ -6277,9 +6277,9 @@
       }
     },
     "node_modules/eslint-plugin-testing-library": {
-      "version": "5.11.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.11.1.tgz",
-      "integrity": "sha512-5eX9e1Kc2PqVRed3taaLnAAqPZGEX75C+M/rXzUAI3wIg/ZxzUm1OVAwfe/O+vE+6YXOLetSe9g5GKD2ecXipw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-6.3.0.tgz",
+      "integrity": "sha512-GYcEErTt6EGwE0bPDY+4aehfEBpB2gDBFKohir8jlATSUvzStEyzCx8QWB/14xeKc/AwyXkzScSzMHnFojkWrA==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/utils": "^5.58.0"
@@ -16718,9 +16718,9 @@
       "requires": {}
     },
     "eslint-plugin-testing-library": {
-      "version": "5.11.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.11.1.tgz",
-      "integrity": "sha512-5eX9e1Kc2PqVRed3taaLnAAqPZGEX75C+M/rXzUAI3wIg/ZxzUm1OVAwfe/O+vE+6YXOLetSe9g5GKD2ecXipw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-6.3.0.tgz",
+      "integrity": "sha512-GYcEErTt6EGwE0bPDY+4aehfEBpB2gDBFKohir8jlATSUvzStEyzCx8QWB/14xeKc/AwyXkzScSzMHnFojkWrA==",
       "dev": true,
       "requires": {
         "@typescript-eslint/utils": "^5.58.0"

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "eslint-plugin-jest-dom": "^5.4.0",
     "eslint-plugin-jsx-a11y": "^6.9.0",
     "eslint-plugin-react": "^7.35.0",
-    "eslint-plugin-testing-library": "^5.11.1",
+    "eslint-plugin-testing-library": "^6.3.0",
     "happy-dom": "^14.12.3",
     "husky": "^9.1.4",
     "i18next": "^23.12.2",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "happy-dom": "^14.12.3",
     "husky": "^9.1.4",
     "i18next": "^23.12.2",
-    "lint-staged": "^15.2.8",
+    "lint-staged": "^15.2.9",
     "mkdirp": "^3.0.1",
     "prettier": "^3.3.3",
     "react": "^18.3.1",


### PR DESCRIPTION
### Description

Updates eslint-plugin-testing-library to v6.
Disables the [`testing-library/no-manual-cleanup`](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-manual-cleanup.md) rule, which is now active by default on the `testing-library/react` config, because vitest doesn't expose global `afferEach` methods. 

_Note_: The lint step in failing in CI for an unrelated reason, which is fixed in #1791.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)