### PR TITLE
Fix: warning each child should have a unique key

### DIFF
--- a/src/TransWithoutContext.js
+++ b/src/TransWithoutContext.js
@@ -298,6 +298,59 @@ const renderNodes = (children, targetString, i18n, i18nOptions, combinedTOpts, s
   return getChildren(result[0]);
 };
 
+const fixComponentProps = (component, index, translation) => {
+  const componentKey = component.key || index;
+  const comp = cloneElement(component, { key: componentKey });
+  if (
+    !comp.props ||
+    !comp.props.children ||
+    (translation.indexOf(`${index}/>`) < 0 && translation.indexOf(`${index} />`) < 0)
+  ) {
+    return comp;
+  }
+
+  function Componentized() {
+    // <>{comp}</>
+    return createElement(Fragment, null, comp);
+  }
+  // <Componentized />
+  return createElement(Componentized);
+};
+
+const generateArrayComponents = (components, translation) =>
+  components.map((c, index) => fixComponentProps(c, index, translation));
+
+const generateObjectComponents = (components, translation) => {
+  const componentMap = {};
+
+  Object.keys(components).forEach((c) => {
+    Object.assign(componentMap, {
+      [c]: fixComponentProps(components[c], c, translation),
+    });
+  });
+
+  return componentMap;
+};
+
+const generateComponents = (components, translation) => {
+  if (!components) return null;
+
+  // components could be either an array or an object
+
+  if (Array.isArray(components)) {
+    return generateArrayComponents(components, translation);
+  }
+
+  if (isObject(components)) {
+    return generateObjectComponents(components, translation);
+  }
+
+  // if components is not an array or an object, warn the user
+  // and return null
+  console.warn('<Trans /> component prop expects an object or an array');
+  return null;
+};
+
 export function Trans({
   children,
   count,
@@ -360,29 +413,10 @@ export function Trans({
   };
   const translation = key ? t(key, combinedTOpts) : defaultValue;
 
-  if (components) {
-    Object.keys(components).forEach((c) => {
-      const componentKey = components[c].key || c;
-      const comp = cloneElement(components[c], { key: componentKey });
-      if (
-        !comp.props ||
-        !comp.props.children ||
-        (translation.indexOf(`${c}/>`) < 0 && translation.indexOf(`${c} />`) < 0)
-      )
-        return;
-
-      // eslint-disable-next-line react/no-unstable-nested-components
-      function Componentized() {
-        // <>{comp}</>
-        return createElement(Fragment, null, comp);
-      }
-      // <Componentized />
-      components[c] = createElement(Componentized);
-    });
-  }
+  const generatedComponents = generateComponents(components, translation);
 
   const content = renderNodes(
-    components || children,
+    generatedComponents || children,
     translation,
     i18n,
     reactI18nextOptions,

--- a/src/TransWithoutContext.js
+++ b/src/TransWithoutContext.js
@@ -347,7 +347,7 @@ const generateComponents = (components, translation) => {
 
   // if components is not an array or an object, warn the user
   // and return null
-  console.warn('<Trans /> component prop expects an object or an array');
+  warnOnce('<Trans /> component prop expects an object or an array');
   return null;
 };
 


### PR DESCRIPTION
#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

@adrai @aiktb @XAOPT When I made the changes in https://github.com/i18next/react-i18next/pull/1813 I wasn't aware of the conditional return, It seems in the example provided here: https://stackblitz.com/edit/vitejs-vite-59g4bx?file=package.json the first [if statement](https://github.com/i18next/react-i18next/blob/master/src/TransWithoutContext.js#L367-L372) in `TransWithoutContext` is returning void causing the unmodified components (without key) to get rendered.

That function handles both arrays and objects using `Object.keys` which is smart but also very confusing. We could revert my changes and the warning will disappear but it will cause errors to show up because those components are readonly, also as specified here in your type: https://github.com/i18next/react-i18next/blob/master/TransWithoutContext.d.ts#L16.

In this pull request I'm attempting to solve both issues, mutating the component prop and the keys warning. I split the function into smaller functions which will return a new components value at the end without overriding it.

It might also fix https://github.com/i18next/react-i18next/issues/1733