### PR TITLE
fix: unique key warning on componentized element

### DIFF
--- a/src/TransWithoutContext.js
+++ b/src/TransWithoutContext.js
@@ -324,7 +324,7 @@ const fixComponentProps = (component, index, translation) => {
     return createElement(Fragment, null, comp);
   }
   // <Componentized />
-  return createElement(Componentized);
+  return createElement(Componentized, { key: componentKey });
 };
 
 const generateArrayComponents = (components, translation) =>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

Fixes the unique key warning that occurs with React 19 when the `Trans` component was used with elements with children. The created `Componentized` element didn't include the original key.

Fixes #1834

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)