### PR TITLE
feat: use const type parameters for useTranslation()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -97,8 +97,8 @@ export type FallbackNs<Ns> = Ns extends undefined
     : _DefaultNamespace;
 
 export function useTranslation<
-  Ns extends FlatNamespace | $Tuple<FlatNamespace> | undefined = undefined,
-  KPrefix extends KeyPrefix<FallbackNs<Ns>> = undefined,
+  const Ns extends FlatNamespace | $Tuple<FlatNamespace> | undefined = undefined,
+  const KPrefix extends KeyPrefix<FallbackNs<Ns>> = undefined,
 >(
   ns?: Ns,
   options?: UseTranslationOptions<KPrefix>,

--- a/package.json
+++ b/package.json
@@ -67,6 +67,14 @@
     "@babel/runtime": "^7.25.0",
     "html-parse-stringify": "^3.0.1"
   },
+  "peerDependencies": {
+    "typescript": "^5"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@babel/cli": "^7.24.8",
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
TypeScript 5.0 has introduced [const type parameters][1]. These indicate that a more specific type is preferred over a more general one. As a result, the resulting UseTranslationResponse will be more precise and retain the passed-in namespace and prefix. This can be used by extractors and other tooling to find out exactly which key is accessed by a translation function call.

[1]: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#const-type-parameters

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included (N/A: there is no way to extract generic type parameters from a test)
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)