### PR TITLE
add typescript as optional peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,13 +67,17 @@
       },
       "peerDependencies": {
         "i18next": ">= 23.2.3",
-        "react": ">= 16.8.0"
+        "react": ">= 16.8.0",
+        "typescript": "^5"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         },
         "react-native": {
+          "optional": true
+        },
+        "typescript": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -69,13 +69,17 @@
   },
   "peerDependencies": {
     "i18next": ">= 23.2.3",
-    "react": ">= 16.8.0"
+    "react": ">= 16.8.0",
+    "typescript": "^5"
   },
   "peerDependenciesMeta": {
     "react-dom": {
       "optional": true
     },
     "react-native": {
+      "optional": true
+    },
+    "typescript": {
       "optional": true
     }
   },


### PR DESCRIPTION
Follow up of https://github.com/i18next/react-i18next/pull/1842 and https://github.com/i18next/react-i18next/commit/ac79767b39fa0baec421b35a430ab73e80a253aa .

@emersion `peerDependencies` and `peerDependenciesMeta` were already present in the `package.json`, 
you duplicated the keys. 
Also remember to run `npm i` after editing `package.json` dependencies related entires.

@adrai you merged the PR and removed the duplicated entries without adding typescript in https://github.com/i18next/react-i18next/commit/ac79767b39fa0baec421b35a430ab73e80a253aa .

