### PR TITLE
Fix element.ref access issue with react 19

### DIFF
--- a/src/TransWithoutContext.js
+++ b/src/TransWithoutContext.js
@@ -170,7 +170,7 @@ const renderNodes = (children, targetString, i18n, i18nOptions, combinedTOpts, s
             {
               ...props,
               key: i,
-              ref: c.ref,
+              ref: c.props.ref ?? c.ref, // ref is a prop in react >= v19
             },
             isVoid ? null : inner,
           );


### PR DESCRIPTION
Since React v19 element.ref access is deprecated and will log an error message when done. This small PR fixes this issue in backwards compatible fashion.

https://react.dev/blog/2024/04/25/react-19-upgrade-guide#deprecated-element-ref

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)