### PR TITLE
feat: adds support for new "selector" API

### DIFF
--- a/TransWithoutContext.d.ts
+++ b/TransWithoutContext.d.ts
@@ -1,40 +1,79 @@
-import type { i18n, ParseKeys, Namespace, TypeOptions, TOptions, TFunction } from 'i18next';
+import type {
+  i18n,
+  ApplyTarget,
+  ConstrainTarget,
+  GetSource,
+  ParseKeys,
+  Namespace,
+  SelectorFn,
+  TypeOptions,
+  TOptions,
+  TFunction,
+} from 'i18next';
 import * as React from 'react';
 
 type _DefaultNamespace = TypeOptions['defaultNS'];
+type _EnableSelector = TypeOptions['enableSelector'];
 
 type TransChild = React.ReactNode | Record<string, unknown>;
-export type TransProps<
-  Key extends ParseKeys<Ns, TOpt, KPrefix>,
+
+/**
+ * This type functionally replaces {@link TransProps}, and should replace it
+ * when cut over from the string-based to the selector API (tentatively v27).
+ *
+ * So if you depend on this type directly, just be aware that it will be renamed
+ * to `TransProps` in a future major version.
+ */
+interface TransPropsInterface<
+  Key,
   Ns extends Namespace = _DefaultNamespace,
   KPrefix = undefined,
   TContext extends string | undefined = undefined,
   TOpt extends TOptions & { context?: TContext } = { context: TContext },
-  E = React.HTMLProps<HTMLDivElement>,
-> = E & {
+> {
   children?: TransChild | readonly TransChild[];
   components?: readonly React.ReactElement[] | { readonly [tagName: string]: React.ReactElement };
   count?: number;
   context?: TContext;
   defaults?: string;
   i18n?: i18n;
-  i18nKey?: Key | Key[];
+  i18nKey?: Key;
   ns?: Ns;
   parent?: string | React.ComponentType<any> | null; // used in React.createElement if not null
   tOptions?: TOpt;
   values?: {};
   shouldUnescape?: boolean;
   t?: TFunction<Ns, KPrefix>;
-};
+}
 
-export function Trans<
+export type GetTransProps<
+  Target extends ConstrainTarget<TOpt>,
   Key extends ParseKeys<Ns, TOpt, KPrefix>,
   Ns extends Namespace = _DefaultNamespace,
   KPrefix = undefined,
   TContext extends string | undefined = undefined,
   TOpt extends TOptions & { context?: TContext } = { context: TContext },
   E = React.HTMLProps<HTMLDivElement>,
->(props: TransProps<Key, Ns, KPrefix, TContext, TOpt, E>): React.ReactElement;
+> = E &
+  TransPropsInterface<
+    _EnableSelector extends true
+      ? SelectorFn<GetSource<NoInfer<Ns>, KPrefix>, ApplyTarget<Target, TOpt>, TOpt>
+      : Key | Key[],
+    Ns,
+    KPrefix,
+    TContext,
+    TOpt
+  >;
+
+export declare function Trans<
+  Key extends ParseKeys<Ns, TOpt, KPrefix>,
+  const Ns extends Namespace = _DefaultNamespace,
+  KPrefix = undefined,
+  TContext extends string | undefined = undefined,
+  TOpt extends TOptions & { context?: TContext } = { context: TContext },
+  E = React.HTMLProps<HTMLDivElement>,
+  Target extends ConstrainTarget<TOpt> = ConstrainTarget<TOpt>,
+>(props: GetTransProps<Target, Key, Ns, KPrefix, TContext, TOpt, E>): React.ReactElement;
 
 export type ErrorCode =
   | 'NO_I18NEXT_INSTANCE'
@@ -71,3 +110,30 @@ export type ErrorMeta = {
  * ```
  */
 export type ErrorArgs = readonly [string, ErrorMeta | undefined, ...any[]];
+
+/**
+ * This type left here in case anyone in userland depends on it -- it's no longer used internally,
+ * and can/should be removed when we cut over to the selector API (tentatively v27)
+ */
+export type TransProps<
+  Key extends ParseKeys<Ns, TOpt, KPrefix>,
+  Ns extends Namespace = _DefaultNamespace,
+  KPrefix = undefined,
+  TContext extends string | undefined = undefined,
+  TOpt extends TOptions & { context?: TContext } = { context: TContext },
+  E = React.HTMLProps<HTMLDivElement>,
+> = E & {
+  children?: TransChild | readonly TransChild[];
+  components?: readonly React.ReactElement[] | { readonly [tagName: string]: React.ReactElement };
+  count?: number;
+  context?: TContext;
+  defaults?: string;
+  i18n?: i18n;
+  i18nKey?: Key | Key[];
+  ns?: Ns;
+  parent?: string | React.ComponentType<any> | null; // used in React.createElement if not null
+  tOptions?: TOpt;
+  values?: {};
+  shouldUnescape?: boolean;
+  t?: TFunction<Ns, KPrefix>;
+};

--- a/test/typescript/selector-custom-types/Trans.test.tsx
+++ b/test/typescript/selector-custom-types/Trans.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import * as React from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+
+describe('<Trans />', () => {
+  describe('default namespace', () => {
+    it('standard usage', () => {
+      <Trans i18nKey={($) => (expectTypeOf($.foo).toMatchTypeOf<'foo'>, $.foo)} />;
+    });
+
+    it(`raises a TypeError given a key that doesn't exist`, () => {
+      // @ts-expect-error
+      <Trans i18nKey={($) => $.Nope} />;
+    });
+  });
+
+  describe('named namespace', () => {
+    it('standard usage', () => {
+      <Trans ns="custom" i18nKey={($) => (expectTypeOf($.foo).toEqualTypeOf<'foo'>, $.foo)} />;
+    });
+
+    it(`raises a TypeError given a namespace that doesn't exist`, () => {
+      expectTypeOf<React.ComponentProps<typeof Trans>>()
+        .toHaveProperty('ns')
+        .extract<'Nope'>()
+        // @ts-expect-error
+        .toMatchTypeOf<'Nope'>();
+    });
+  });
+
+  describe('array namespace', () => {
+    it('should work with array namespace', () => (
+      <>
+        <Trans
+          ns={['alternate', 'custom']}
+          i18nKey={($) => (expectTypeOf($.baz).toEqualTypeOf<'baz'>(), $.baz)}
+        />
+        <Trans
+          ns={['alternate', 'custom']}
+          i18nKey={($) => (expectTypeOf($.custom.bar).toEqualTypeOf<'bar'>(), $.custom.bar)}
+        />
+        <Trans
+          ns={['custom', 'alternate']}
+          i18nKey={($) => (expectTypeOf($.alternate.baz).toEqualTypeOf<'baz'>(), $.alternate.baz)}
+        />
+        <Trans
+          ns={['custom', 'alternate']}
+          i18nKey={($) => (expectTypeOf($.bar).toEqualTypeOf<'bar'>(), $.bar)}
+        />
+        <Trans
+          ns={['custom', 'alternate']}
+          i18nKey={($) => (
+            expectTypeOf($.alternate.foobar.deep.deeper.deeeeeper).toEqualTypeOf<'foobar'>(),
+            $.alternate.foobar.deep.deeper.deeeeeper
+          )}
+        />
+      </>
+    ));
+
+    it(`raises a TypeError given a key that's not present inside any namespace`, () => {
+      // @ts-expect-error
+      <Trans ns={['alternate', 'custom']} i18nKey={($) => $.alternate.baz} />;
+      // @ts-expect-error
+      <Trans ns={['alternate', 'custom']} i18nKey={($) => $.custom.baz} />;
+    });
+  });
+
+  describe('usage with `t` function', () => {
+    it('should work when providing `t` function', () => {
+      const { t } = useTranslation('alternate');
+      <Trans
+        t={t}
+        i18nKey={($) => (expectTypeOf($.foobar.barfoo).toEqualTypeOf<'barfoo'>(), $.foobar.barfoo)}
+      />;
+    });
+
+    it('should work when providing `t` function with a prefix', () => {
+      const { t } = useTranslation('alternate', { keyPrefix: 'foobar.deep' });
+      <Trans
+        t={t}
+        i18nKey={($) => (
+          expectTypeOf($.deeper.deeeeeper).toEqualTypeOf<'foobar'>(), $.deeper.deeeeeper
+        )}
+      />;
+    });
+
+    it('raises a TypeError given a key-prefixed `t` function and an invalid key', () => {
+      const { t } = useTranslation('alternate', { keyPrefix: 'foobar.deep' });
+      // @ts-expect-error
+      <Trans t={t} i18nKey={($) => $.xxx} />;
+    });
+  });
+
+  describe('interpolation', () => {
+    it('should work with text and interpolation', () => {
+      expectTypeOf(Trans).toBeCallableWith({
+        children: <>foo {{ var: '' }}</>,
+      });
+    });
+
+    it('should work with Interpolation in HTMLElement', () => {
+      expectTypeOf(Trans).toBeCallableWith({
+        children: (
+          <>
+            foo <strong>{{ var: '' }}</strong>
+          </>
+        ),
+      });
+    });
+
+    it('should work with text and interpolation as children of an  HTMLElement', () => {
+      expectTypeOf(Trans).toBeCallableWith({
+        children: <span>foo {{ var: '' }}</span>,
+      });
+    });
+  });
+});

--- a/test/typescript/selector-custom-types/TransWithoutContext.test.tsx
+++ b/test/typescript/selector-custom-types/TransWithoutContext.test.tsx
@@ -1,0 +1,173 @@
+import { describe, it, expectTypeOf, assertType } from 'vitest';
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Trans } from '../../../TransWithoutContext';
+
+describe('<Trans />', () => {
+  describe('default namespace', () => {
+    it('standard usage', () => {
+      <Trans i18nKey={($) => $.foo}>foo</Trans>;
+    });
+
+    it("raises a TypeError given a key that doesn't exist", () => {
+      expectTypeOf<React.ComponentProps<typeof Trans>>()
+        .toHaveProperty('i18nKey')
+        .extract<'Nope'>()
+        // @ts-expect-error
+        .toMatchTypeOf<'Nope'>();
+    });
+  });
+
+  describe('named namespace', () => {
+    it('standard usage', () => {
+      <Trans ns="custom" i18nKey={($) => $.foo}></Trans>;
+    });
+
+    it("raises a TypeError given a namespace that doesn't exist", () => {
+      expectTypeOf<React.ComponentProps<typeof Trans>>()
+        .toHaveProperty('ns')
+        .extract<'Nope'>()
+        // @ts-expect-error
+        .toMatchTypeOf<'Nope'>();
+    });
+  });
+
+  describe('array namespace', () => {
+    it('should work with array namespace', () => {
+      <Trans ns={['alternate', 'custom']} i18nKey={($) => $.baz} />;
+      <Trans ns={['alternate', 'custom']} i18nKey={($) => $.custom.bar} />;
+      <Trans ns={['custom', 'alternate']} i18nKey={($) => $.bar} />;
+      <Trans ns={['custom', 'alternate']} i18nKey={($) => $.alternate.baz} />;
+
+      /**
+       * TODO: figure out what to do about default/fallback values?
+       *
+       * Currently, `Trans` doesn't accept a 'defaultValue' prop, like the
+       * `t` function does.
+       *
+       * I could add that, or we could try something different -- wanted to get
+       * feedback on this before starting down any particular path
+       */
+      // expectTypeOf(Trans).toBeCallableWith({
+      //   ns: ['alternate', 'custom'],
+      //   i18nKey: ['alternate:baz', 'custom:bar'],
+      // });
+    });
+
+    it('raises a TypeError given a key not present inside the current namespace', () => {
+      // @ts-expect-error
+      <Trans ns={['alternate', 'custom']} i18nKey={($) => $.alternate.baz} />;
+      // @ts-expect-error
+      <Trans ns={['alternate', 'custom']} i18nKey={($) => $.bar} />;
+      // @ts-expect-error
+      <Trans ns={['custom', 'alternate']} i18nKey={($) => $.custom.bar} />;
+      // @ts-expect-error
+      <Trans ns={['custom', 'alternate']} i18nKey={($) => $.baz} />;
+    });
+  });
+
+  describe('usage with `t` function', () => {
+    it('should work when providing `t` function', () => {
+      const { t } = useTranslation('alternate');
+
+      <Trans t={t} i18nKey={($) => $.foobar.barfoo}>
+        foo
+      </Trans>;
+    });
+
+    it('should work when providing `t` function with a prefix', () => {
+      const { t } = useTranslation('alternate', { keyPrefix: 'foobar.deep' });
+
+      <Trans t={t} i18nKey={($) => $.deeper.deeeeeper}>
+        foo
+      </Trans>;
+    });
+
+    it('raises a TypeError given a `t` function with key prefix when the key is invalid', () => {
+      const { t } = useTranslation('alternate', { keyPrefix: 'foobar.deep' });
+
+      // @ts-expect-error
+      <Trans t={t} i18nKey={($) => $.xxx}>
+        foo
+      </Trans>;
+    });
+  });
+
+  describe('interpolation', () => {
+    it('should work with text and interpolation', () => {
+      expectTypeOf(Trans).toBeCallableWith({
+        children: <>foo {{ var: '' }}</>,
+      });
+    });
+
+    it('should work with Interpolation in HTMLElement', () => {
+      expectTypeOf(Trans).toBeCallableWith({
+        children: (
+          <>
+            foo <strong>{{ var: '' }}</strong>
+          </>
+        ),
+      });
+    });
+
+    it('should work with text and interpolation as children of an HTMLElement', () => {
+      expectTypeOf(Trans).toBeCallableWith({
+        children: <span>foo {{ var: '' }}</span>,
+      });
+    });
+  });
+
+  describe('usage with context', () => {
+    it('should work with default namespace', () => {
+      assertType<React.ReactElement>(<Trans i18nKey={($) => $.some} context="me" />);
+    });
+
+    it('raises a TypeError when context is invalid', () => {
+      // @ts-expect-error
+      assertType<React.ReactElement>(<Trans i18nKey={($) => $.some} context="one" />);
+    });
+
+    it('should work with `ns` prop', () => {
+      assertType<React.ReactElement>(<Trans ns="context" i18nKey={($) => $.beverage} />);
+    });
+
+    it('raises a TypeError given a namespace when context is invalid', () => {
+      assertType<React.ReactElement>(
+        // @ts-expect-error
+        <Trans ns="context" i18nKey={($) => $.beverage} context="strawberry" />,
+      );
+    });
+
+    it('should work with default `t` function', () => {
+      const { t } = useTranslation();
+
+      assertType<React.ReactElement>(<Trans t={t} i18nKey={($) => $.some} context="me" />);
+    });
+
+    it('raises a TypeError given a defaut `t` function when context is invalid', () => {
+      // @ts-expect-error should
+      assertType<React.ReactElement>(<Trans t={t} i18nKey={($) => $.some} context="Test1222" />);
+    });
+
+    it('should work with custom `t` function', () => {
+      const { t } = useTranslation('context');
+
+      assertType<React.ReactElement>(<Trans t={t} i18nKey={($) => $.dessert} context="cake" />);
+    });
+
+    it('raises a TypeError given a custom `t` function when context is invalid', () => {
+      // @ts-expect-error
+      assertType<React.ReactElement>(<Trans t={t} i18nKey="dessert" context="sake" />);
+    });
+
+    it('should work with `ns` prop and `count` prop', () => {
+      const { t } = useTranslation('plurals');
+      assertType<React.ReactElement>(<Trans ns="plurals" i18nKey={($) => $.foo} count={2} />);
+    });
+
+    it('should work with custom `t` function and `count` prop', () => {
+      const { t } = useTranslation('plurals');
+      assertType<React.ReactElement>(<Trans t={t} i18nKey={($) => $.foo} count={2} />);
+    });
+  });
+});

--- a/test/typescript/selector-custom-types/Translation.test.tsx
+++ b/test/typescript/selector-custom-types/Translation.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import { Translation } from 'react-i18next';
+import React from 'react';
+
+describe('<Translation />', () => {
+  it('should work with default namespace', () => (
+    <Translation>{(t) => t(($) => $.foo)}</Translation>
+  ));
+
+  it('should work with named default namespace', () => (
+    <Translation ns="custom">{(t) => t(($) => $.foo)}</Translation>
+  ));
+
+  it('should work with named namespace', () => (
+    <Translation ns="alternate">{(t) => t(($) => $.baz)}</Translation>
+  ));
+
+  it('should work with namespace array', () => {
+    <Translation ns={['alternate', 'custom']}>
+      {(t) => `${t(($) => $.baz)} ${t(($) => $.custom.foo)}`}
+    </Translation>;
+  });
+
+  it("raises a TypeError given a namespace that doesn't exist", () => {
+    // @ts-expect-error
+    <Translation>{(t) => t.fake}</Translation>;
+  });
+
+  it("raises a TypeError given a key that's not in the namespace", () => {
+    // @ts-expect-error
+    <Translation ns="custom">{(t) => t.fake}</Translation>;
+  });
+
+  it("raises a TypeError given a key that's not in the namespace (with namespace as prefix)", () => {
+    // @ts-expect-error
+    <Translation ns="custom">{(t) => t.custom.fake}</Translation>;
+  });
+});

--- a/test/typescript/selector-custom-types/i18next.d.ts
+++ b/test/typescript/selector-custom-types/i18next.d.ts
@@ -1,0 +1,47 @@
+import 'i18next';
+
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    defaultNS: 'custom';
+    allowObjectInHTMLChildren: true;
+    enableSelector: true;
+    resources: {
+      custom: {
+        foo: 'foo';
+        bar: 'bar';
+
+        some: 'some';
+        some_me: 'some context';
+      };
+
+      alternate: {
+        baz: 'baz';
+        foobar: {
+          barfoo: 'barfoo';
+          deep: {
+            deeper: {
+              deeeeeper: 'foobar';
+            };
+          };
+        };
+      };
+
+      plurals: {
+        foo_zero: 'foo';
+        foo_one: 'foo';
+        foo_two: 'foo';
+        foo_many: 'foo';
+        foo_other: 'foo';
+      };
+
+      context: {
+        dessert_cake: 'a nice cake';
+        dessert_muffin_one: 'a nice muffin';
+        dessert_muffin_other: '{{count}} nice muffins';
+
+        beverage: 'beverage';
+        beverage_beer: 'beer';
+      };
+    };
+  }
+}

--- a/test/typescript/selector-custom-types/tsconfig.json
+++ b/test/typescript/selector-custom-types/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["./**/*"],
+  "exclude": []
+}

--- a/test/typescript/selector-custom-types/useTranslation.test.ts
+++ b/test/typescript/selector-custom-types/useTranslation.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expectTypeOf, assertType } from 'vitest';
+import { useTranslation } from 'react-i18next';
+import { TFunction, i18n } from 'i18next';
+
+describe('useTranslation', () => {
+  it('should provide result with both object and array', () => {
+    const result = useTranslation();
+
+    expectTypeOf(result).toMatchTypeOf<[TFunction, i18n, boolean]>();
+    expectTypeOf(result).toHaveProperty('ready').toBeBoolean();
+    expectTypeOf(result).toHaveProperty('t').toBeFunction();
+    expectTypeOf(result).toHaveProperty('i18n').toBeObject();
+  });
+
+  describe('default namespace', () => {
+    it('should work with default namespace', () => {
+      const [t] = useTranslation();
+
+      expectTypeOf(t).toBeCallableWith(($) => $.foo);
+    });
+
+    it('should work with default named namespace', () => {
+      const [t] = useTranslation('custom');
+
+      expectTypeOf(t).toBeCallableWith(($) => $.bar);
+    });
+  });
+
+  describe('named namespace', () => {
+    it('should work with named namespace', () => {
+      const [t] = useTranslation('alternate');
+
+      expectTypeOf(t).toBeCallableWith(($) => $.baz);
+    });
+
+    it(`raises a TypeError given a namespace that doesn't exist`, () => {
+      // @ts-expect-error
+      const [t] = useTranslation(($) => $.fake);
+    });
+
+    it(`raises a TypeError given a key that's not in the namespace`, () => {
+      const [t] = useTranslation('custom');
+      // @ts-expect-error
+      assertType<string>(t(($) => $.fake));
+    });
+  });
+
+  describe('namespace as array', () => {
+    it('should work with const namespaces', () => {
+      const [t] = useTranslation(['alternate', 'custom']);
+
+      expectTypeOf(t(($) => $.baz)).toEqualTypeOf<'baz'>();
+      expectTypeOf(t(($) => $.baz, { ns: 'alternate' })).toEqualTypeOf<'baz'>();
+      expectTypeOf(t(($) => $.custom.foo)).toEqualTypeOf<'foo'>();
+      expectTypeOf(t(($) => $.foo, { ns: 'custom' })).toEqualTypeOf<'foo'>();
+    });
+
+    it('should work with const namespaces', () => {
+      const namespaces = ['alternate', 'custom'] as const;
+      const [t] = useTranslation(namespaces);
+
+      expectTypeOf(t(($) => $.baz)).toEqualTypeOf<'baz'>();
+      expectTypeOf(t(($) => $.baz, { ns: 'alternate' })).toEqualTypeOf<'baz'>();
+      expectTypeOf(t(($) => $.custom.foo)).toEqualTypeOf<'foo'>();
+      expectTypeOf(t(($) => $.foo, { ns: 'custom' })).toEqualTypeOf<'foo'>();
+    });
+
+    it('raises a TypeError given an incorrect key', () => {
+      const [t] = useTranslation(['custom']);
+      // @ts-expect-error
+      assertType<string>(t(($) => $.custom.fake));
+      // @ts-expect-error
+      assertType<string>(t(($) => $.fake, { ns: 'custom' }));
+    });
+  });
+
+  describe('with `keyPrefix`', () => {
+    it('should provide top-level string keys', () => {
+      const [t] = useTranslation('alternate', { keyPrefix: 'foobar' });
+
+      expectTypeOf(t(($) => $.barfoo)).toEqualTypeOf<'barfoo'>();
+    });
+
+    it('should work with deeper objects', () => {
+      const [t] = useTranslation('alternate', { keyPrefix: 'foobar.deep' });
+
+      expectTypeOf(t(($) => $.deeper, { returnObjects: true })).toEqualTypeOf<{
+        deeeeeper: 'foobar';
+      }>();
+      expectTypeOf(t(($) => $.deeper.deeeeeper)).toEqualTypeOf<'foobar'>();
+    });
+
+    it('raises a TypeError given an invalid keyPrefix', () => {
+      // @ts-expect-error
+      useTranslation('alternate', { keyPrefix: 'abc' });
+    });
+
+    it('raises a TypeError given an invalid key', () => {
+      const [t] = useTranslation('alternate', { keyPrefix: 'foobar' });
+      // @ts-expect-error
+      assertType<string>(t('abc'));
+    });
+  });
+
+  it('should work with json format v4 plurals', () => {
+    const [t] = useTranslation('plurals');
+
+    expectTypeOf(t(($) => $.foo, { count: 0 })).toEqualTypeOf<'foo'>();
+  });
+
+  it('raises a TypeError when attempting to select a pluralized key with a specific pluralized suffix', () => {
+    const [t] = useTranslation('plurals');
+
+    // @ts-expect-error
+    expectTypeOf(t(($) => $.foo_one)).toEqualTypeOf<'foo'>();
+  });
+});


### PR DESCRIPTION
[By request](https://github.com/i18next/i18next/pull/2322#discussion_r2173140428), this PR accompanies [i18next/#2322](https://github.com/i18next/i18next/pull/2322).

### Todo:


- [ ] **Decide:** how should we handle "fallback" selections, as outline in [this comment](https://github.com/i18next/react-i18next/compare/master...ahrjarrett:react-i18next-fork:selector?expand=1#diff-ab6d573d173585851228df6601b94bcbca7534ea4bc09aadb19ef34b235110b5R42-R55)?


#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)