### PR TITLE
Fix: passing components as object should still allow for indexed matching of children

### DIFF
--- a/test/trans.render.object.spec.jsx
+++ b/test/trans.render.object.spec.jsx
@@ -273,6 +273,34 @@ describe('trans using children but components (object) - self closing tag', () =
   });
 });
 
+describe('trans using children and components (object) - should still allow for use of indexed basic html tags in children', () => {
+  function TestComponent() {
+    return (
+      <Trans
+        i18nKey="some key"
+        defaults="Click <1>here</1> to continue"
+        components={{ unused: <span /> }}
+      >
+        pre <a href="#">link</a> post
+      </Trans>
+    );
+  }
+  it('should render translated string', () => {
+    const { container } = render(<TestComponent />);
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <div>
+        Click 
+        <a
+          href="#"
+        >
+          here
+        </a>
+         to continue
+      </div>
+    `);
+  });
+});
+
 describe('trans using no children but components (object) - interpolated component with children', () => {
   function Button({ children }) {
     return <button type="button">{children}</button>;


### PR DESCRIPTION
I encountered what I think is a bug.

Consider the following case:

```
<Trans i18nKey="tkey" default="Click <1>here</1> to continue">
  pre <a href="#somewhere">link</a> post
</Trans>
```

This outputs `Click [here](#somewhere) to continue` as expected. However I expect that it keeps working even if I pass in a components map that isn't actually used:

```
<Trans i18nKey="tkey" default="Click <1>here</1> to continue" components={{ unused: <span /> }}>
  pre <a href="#somewhere">link</a> post
</Trans>
```

Before my change this would no longer match `<1>` to the `<a>` passed in children, because children was being ignored by the components map. Part of the code wrongfully assumes that `components` contains something like `{ 1: <a href="#somewhere> }`, but it doesn't in this case; I'm using `components` as a map, not an index - which is also definitely supported!

I struggled a bit with the code because `children` is very polymorphic, the code has poorly named variables, and logic is all over the place; luckily the tests are good so I'm confident this doesn't break any other use case 😅

#### Checklist

- [ x ] only relevant code is changed (make a diff before you submit the PR)
- [ x ] run tests `npm run test`
- [ x ] tests are included
- [ x ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)