### PR TITLE
Fix: `_EnableSelector` type (for compatibility, enableSelector does not exist in TypeOptions)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -67,7 +67,8 @@ type _DefaultNamespace = TypeOptions['defaultNS'];
 
 export function useSSR(initialI18nStore: Resource, initialLanguage: string): void;
 
-type _EnableSelector = TypeOptions['enableSelector'];
+// If the version is earlier than i18next v25.4.0, enableSelector does not exist in TypeOptions, so a conditional type is used to maintain type compatibility.
+type _EnableSelector = TypeOptions extends { enableSelector: infer U } ? U : false;
 
 export type UseTranslationOptions<KPrefix> = {
   i18n?: i18n;


### PR DESCRIPTION
Hello,

I have updated to v15.7.0, but I encountered a case where type inference with `useTranslation()` does not work correctly.

In my project, I am using i18next v25.3.x.
(I am aware that updating to v25.4 would resolve the issue.)

Since `enableSelector` is not defined in `TypeOptions`, type inference is failing.

<img width="1001" height="478" alt="ss-inferred-any" src="https://github.com/user-attachments/assets/9aeb578a-afcc-4e83-bd8f-e6a1c8d56bc4" />

Looking at the peerDependencies, I noticed that `"i18next": ">= 23.2.3"` is specified.
Considering compatibility, I thought it would be appropriate to handle cases where `enableSelector` is not present in `TypeOptions`, so I made this PR.

Thank you for your consideration.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
