### PR TITLE
feat: add IcuTrans component for eventual use in icu.macro

### DIFF
--- a/src/IcuTrans.js
+++ b/src/IcuTrans.js
@@ -1,0 +1,103 @@
+import { useContext } from 'react';
+import { IcuTransWithoutContext } from './IcuTransWithoutContext.js';
+import { getI18n, I18nContext } from './context.js';
+
+/**
+ * IcuTrans component for rendering ICU MessageFormat translations with React components
+ *
+ * This component provides a context-aware wrapper around IcuTransWithoutContext,
+ * automatically retrieving the i18n instance from React context when used within
+ * an I18nextProvider. It uses a declaration tree approach where components are
+ * defined as type + props blueprints, fetches the translated string, and reconstructs
+ * the React element tree by replacing numbered tags with actual components.
+ *
+ * Key features:
+ * - Supports React Context (I18nextProvider)
+ * - Falls back to global i18n instance
+ * - ICU MessageFormat compatible
+ * - Type-safe component declarations
+ * - Automatic HTML entity decoding
+ *
+ * @param {Object} props - Component props
+ * @param {string} props.i18nKey - The i18n key to look up the translation
+ * @param {string} props.defaultTranslation - The default translation in ICU format with numbered tags (e.g., "<0>Click here</0>")
+ * @param {Array<{type: string|React.ComponentType, props?: Object}>} props.content - Declaration tree describing React components and their props
+ * @param {string|string[]} [props.ns] - Optional namespace(s) for the translation
+ * @param {Object} [props.values] - Optional values for ICU variable interpolation
+ * @param {Object} [props.i18n] - Optional i18next instance (overrides context)
+ * @param {Function} [props.t] - Optional translation function (overrides context)
+ * @returns {React.ReactElement} React fragment containing the rendered translation
+ *
+ * @example
+ * ```jsx
+ * // Basic usage with context
+ * <I18nextProvider i18n={i18n}>
+ *   <IcuTrans
+ *     i18nKey="welcome.message"
+ *     defaultTranslation="Welcome <0>friend</0>!"
+ *     content={[
+ *       { type: 'strong', props: { className: 'highlight' } }
+ *     ]}
+ *   />
+ * </I18nextProvider>
+ * ```
+ *
+ * @example
+ * ```jsx
+ * // With custom components and nested structure
+ * <IcuTrans
+ *   i18nKey="docs.link"
+ *   defaultTranslation="Read the <0>documentation <1></1></0> for more info"
+ *   content={[
+ *     { type: 'a', props: { href: '/docs' } },
+ *     { type: Icon, props: { name: 'external' } }
+ *   ]}
+ * />
+ * ```
+ *
+ * @example
+ * ```jsx
+ * // With nested children in declarations
+ * <IcuTrans
+ *   i18nKey="list.items"
+ *   defaultTranslation="<0><0>First item</0><1>Second item</1></0>"
+ *   content={[
+ *     {
+ *       type: 'ul',
+ *       props: {
+ *         children: [
+ *           { type: 'li', props: {} },
+ *           { type: 'li', props: {} }
+ *         ]
+ *       }
+ *     }
+ *   ]}
+ * />
+ * ```
+ */
+export function IcuTrans({
+  i18nKey,
+  defaultTranslation,
+  content,
+  ns,
+  values = {},
+  i18n: i18nFromProps,
+  t: tFromProps,
+}) {
+  const { i18n: i18nFromContext, defaultNS: defaultNSFromContext } = useContext(I18nContext) || {};
+  const i18n = i18nFromProps || i18nFromContext || getI18n();
+
+  const t = tFromProps || i18n?.t.bind(i18n);
+
+  return IcuTransWithoutContext({
+    i18nKey,
+    defaultTranslation,
+    content,
+    ns: ns || t?.ns || defaultNSFromContext || i18n?.options?.defaultNS,
+    values,
+    i18n,
+    t: tFromProps,
+  });
+}
+
+IcuTrans.displayName = 'IcuTrans';

--- a/src/IcuTransUtils/TranslationParserError.js
+++ b/src/IcuTransUtils/TranslationParserError.js
@@ -1,0 +1,24 @@
+/**
+ * Error thrown during translation parsing
+ */
+export class TranslationParserError extends Error {
+  /**
+   * @param {string} message - Error message
+   * @param {number} [position] - Position in the translation string where the error occurred
+   * @param {string} [translationString] - The full translation string being parsed
+   */
+  constructor(message, position, translationString) {
+    super(message);
+
+    this.name = 'TranslationParserError';
+
+    this.position = position;
+
+    this.translationString = translationString;
+
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, TranslationParserError);
+    }
+  }
+}

--- a/src/IcuTransUtils/htmlEntityDecoder.js
+++ b/src/IcuTransUtils/htmlEntityDecoder.js
@@ -1,0 +1,264 @@
+/**
+ * Common HTML entities map for fast lookup
+ */
+const commonEntities = {
+  // Basic entities
+  '&nbsp;': '\u00A0', // Non-breaking space
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&apos;': "'",
+
+  // Copyright, trademark, and registration
+  '&copy;': '©',
+  '&reg;': '®',
+  '&trade;': '™',
+
+  // Punctuation
+  '&hellip;': '…',
+  '&ndash;': '–',
+  '&mdash;': '—',
+  '&lsquo;': '\u2018',
+  '&rsquo;': '\u2019',
+  '&sbquo;': '\u201A',
+  '&ldquo;': '\u201C',
+  '&rdquo;': '\u201D',
+  '&bdquo;': '\u201E',
+  '&dagger;': '†',
+  '&Dagger;': '‡',
+  '&bull;': '•',
+  '&prime;': '′',
+  '&Prime;': '″',
+  '&lsaquo;': '‹',
+  '&rsaquo;': '›',
+  '&sect;': '§',
+  '&para;': '¶',
+  '&middot;': '·',
+
+  // Spaces
+  '&ensp;': '\u2002',
+  '&emsp;': '\u2003',
+  '&thinsp;': '\u2009',
+
+  // Currency
+  '&euro;': '€',
+  '&pound;': '£',
+  '&yen;': '¥',
+  '&cent;': '¢',
+  '&curren;': '¤',
+
+  // Math symbols
+  '&times;': '×',
+  '&divide;': '÷',
+  '&minus;': '−',
+  '&plusmn;': '±',
+  '&ne;': '≠',
+  '&le;': '≤',
+  '&ge;': '≥',
+  '&asymp;': '≈',
+  '&equiv;': '≡',
+  '&infin;': '∞',
+  '&int;': '∫',
+  '&sum;': '∑',
+  '&prod;': '∏',
+  '&radic;': '√',
+  '&part;': '∂',
+  '&permil;': '‰',
+  '&deg;': '°',
+  '&micro;': 'µ',
+
+  // Arrows
+  '&larr;': '←',
+  '&uarr;': '↑',
+  '&rarr;': '→',
+  '&darr;': '↓',
+  '&harr;': '↔',
+  '&crarr;': '↵',
+  '&lArr;': '⇐',
+  '&uArr;': '⇑',
+  '&rArr;': '⇒',
+  '&dArr;': '⇓',
+  '&hArr;': '⇔',
+
+  // Greek letters (lowercase)
+  '&alpha;': 'α',
+  '&beta;': 'β',
+  '&gamma;': 'γ',
+  '&delta;': 'δ',
+  '&epsilon;': 'ε',
+  '&zeta;': 'ζ',
+  '&eta;': 'η',
+  '&theta;': 'θ',
+  '&iota;': 'ι',
+  '&kappa;': 'κ',
+  '&lambda;': 'λ',
+  '&mu;': 'μ',
+  '&nu;': 'ν',
+  '&xi;': 'ξ',
+  '&omicron;': 'ο',
+  '&pi;': 'π',
+  '&rho;': 'ρ',
+  '&sigma;': 'σ',
+  '&tau;': 'τ',
+  '&upsilon;': 'υ',
+  '&phi;': 'φ',
+  '&chi;': 'χ',
+  '&psi;': 'ψ',
+  '&omega;': 'ω',
+
+  // Greek letters (uppercase)
+  '&Alpha;': 'Α',
+  '&Beta;': 'Β',
+  '&Gamma;': 'Γ',
+  '&Delta;': 'Δ',
+  '&Epsilon;': 'Ε',
+  '&Zeta;': 'Ζ',
+  '&Eta;': 'Η',
+  '&Theta;': 'Θ',
+  '&Iota;': 'Ι',
+  '&Kappa;': 'Κ',
+  '&Lambda;': 'Λ',
+  '&Mu;': 'Μ',
+  '&Nu;': 'Ν',
+  '&Xi;': 'Ξ',
+  '&Omicron;': 'Ο',
+  '&Pi;': 'Π',
+  '&Rho;': 'Ρ',
+  '&Sigma;': 'Σ',
+  '&Tau;': 'Τ',
+  '&Upsilon;': 'Υ',
+  '&Phi;': 'Φ',
+  '&Chi;': 'Χ',
+  '&Psi;': 'Ψ',
+  '&Omega;': 'Ω',
+
+  // Latin extended
+  '&Agrave;': 'À',
+  '&Aacute;': 'Á',
+  '&Acirc;': 'Â',
+  '&Atilde;': 'Ã',
+  '&Auml;': 'Ä',
+  '&Aring;': 'Å',
+  '&AElig;': 'Æ',
+  '&Ccedil;': 'Ç',
+  '&Egrave;': 'È',
+  '&Eacute;': 'É',
+  '&Ecirc;': 'Ê',
+  '&Euml;': 'Ë',
+  '&Igrave;': 'Ì',
+  '&Iacute;': 'Í',
+  '&Icirc;': 'Î',
+  '&Iuml;': 'Ï',
+  '&ETH;': 'Ð',
+  '&Ntilde;': 'Ñ',
+  '&Ograve;': 'Ò',
+  '&Oacute;': 'Ó',
+  '&Ocirc;': 'Ô',
+  '&Otilde;': 'Õ',
+  '&Ouml;': 'Ö',
+  '&Oslash;': 'Ø',
+  '&Ugrave;': 'Ù',
+  '&Uacute;': 'Ú',
+  '&Ucirc;': 'Û',
+  '&Uuml;': 'Ü',
+  '&Yacute;': 'Ý',
+  '&THORN;': 'Þ',
+  '&szlig;': 'ß',
+  '&agrave;': 'à',
+  '&aacute;': 'á',
+  '&acirc;': 'â',
+  '&atilde;': 'ã',
+  '&auml;': 'ä',
+  '&aring;': 'å',
+  '&aelig;': 'æ',
+  '&ccedil;': 'ç',
+  '&egrave;': 'è',
+  '&eacute;': 'é',
+  '&ecirc;': 'ê',
+  '&euml;': 'ë',
+  '&igrave;': 'ì',
+  '&iacute;': 'í',
+  '&icirc;': 'î',
+  '&iuml;': 'ï',
+  '&eth;': 'ð',
+  '&ntilde;': 'ñ',
+  '&ograve;': 'ò',
+  '&oacute;': 'ó',
+  '&ocirc;': 'ô',
+  '&otilde;': 'õ',
+  '&ouml;': 'ö',
+  '&oslash;': 'ø',
+  '&ugrave;': 'ù',
+  '&uacute;': 'ú',
+  '&ucirc;': 'û',
+  '&uuml;': 'ü',
+  '&yacute;': 'ý',
+  '&thorn;': 'þ',
+  '&yuml;': 'ÿ',
+
+  // Special characters
+  '&iexcl;': '¡',
+  '&iquest;': '¿',
+  '&fnof;': 'ƒ',
+  '&circ;': 'ˆ',
+  '&tilde;': '˜',
+  '&OElig;': 'Œ',
+  '&oelig;': 'œ',
+  '&Scaron;': 'Š',
+  '&scaron;': 'š',
+  '&Yuml;': 'Ÿ',
+  '&ordf;': 'ª',
+  '&ordm;': 'º',
+  '&macr;': '¯',
+  '&acute;': '´',
+  '&cedil;': '¸',
+  '&sup1;': '¹',
+  '&sup2;': '²',
+  '&sup3;': '³',
+  '&frac14;': '¼',
+  '&frac12;': '½',
+  '&frac34;': '¾',
+
+  // Card suits
+  '&spades;': '♠',
+  '&clubs;': '♣',
+  '&hearts;': '♥',
+  '&diams;': '♦',
+
+  // Miscellaneous
+  '&loz;': '◊',
+  '&oline;': '‾',
+  '&frasl;': '⁄',
+  '&weierp;': '℘',
+  '&image;': 'ℑ',
+  '&real;': 'ℜ',
+  '&alefsym;': 'ℵ',
+};
+
+// Create regex pattern for all entities
+const entityPattern = new RegExp(
+  Object.keys(commonEntities)
+    .map((entity) => entity.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('|'),
+  'g',
+);
+
+/**
+ * Decode HTML entities in text
+ *
+ * Uses a hybrid approach:
+ * 1. First pass: decode common named entities using a map
+ * 2. Second pass: decode numeric entities (decimal and hexadecimal)
+ *
+ * @param {string} text - Text with HTML entities
+ * @returns {string} Decoded text
+ */
+export const decodeHtmlEntities = (text) =>
+  text
+    // First pass: common named entities
+    .replace(entityPattern, (match) => commonEntities[match])
+    // Second pass: numeric entities (decimal)
+    .replace(/&#(\d+);/g, (_, num) => String.fromCharCode(parseInt(num, 10)))
+    // Third pass: numeric entities (hexadecimal)
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)));

--- a/src/IcuTransUtils/index.js
+++ b/src/IcuTransUtils/index.js
@@ -1,0 +1,4 @@
+export * from './TranslationParserError';
+export * from './htmlEntityDecoder';
+export * from './tokenizer';
+export * from './renderTranslation';

--- a/src/IcuTransUtils/renderTranslation.js
+++ b/src/IcuTransUtils/renderTranslation.js
@@ -1,0 +1,215 @@
+import React from 'react';
+
+import { TranslationParserError } from './TranslationParserError';
+import { tokenize } from './tokenizer';
+import { decodeHtmlEntities } from './htmlEntityDecoder';
+
+/**
+ * Render a React element tree from a declaration node and its children
+ *
+ * @param {Object} declaration - The component declaration (type + props)
+ * @param {Array<React.ReactNode>} children - Array of child nodes (text, numbers, React elements)
+ * @param {Array<Object>} [childDeclarations] - Optional array of child declarations to use for nested rendering
+ * @returns {React.ReactElement} A React element
+ */
+const renderDeclarationNode = (declaration, children, childDeclarations) => {
+  const { type, props = {} } = declaration;
+
+  // If props contain a children declaration AND we have childDeclarations to work with,
+  // we need to recursively render the content with those child declarations
+  if (props.children && Array.isArray(props.children) && childDeclarations) {
+    // The children array contains the parsed content from inside this tag
+    // We need to rebuild the translation string and re-parse it with child declarations
+    // For now, we'll use the children directly as they're already parsed
+    // This happens when renderTranslation is called recursively
+
+    // Remove children from props since we'll pass them as the third argument
+    // eslint-disable-next-line no-unused-vars
+    const { children: _childrenToRemove, ...propsWithoutChildren } = props;
+
+    return React.createElement(type, propsWithoutChildren, ...children);
+  }
+
+  // Standard rendering with children from translation
+  if (children.length === 0) {
+    return React.createElement(type, props);
+  }
+  if (children.length === 1) {
+    return React.createElement(type, props, children[0]);
+  }
+  return React.createElement(type, props, ...children);
+};
+
+/**
+ * Render translation string with declaration tree to create React elements
+ *
+ * This function parses an ICU format translation string and reconstructs
+ * a React element tree using the provided declaration tree. It replaces
+ * numbered tags (e.g., <0>, <1>) with the corresponding components from
+ * the declaration array and fills them with the translated text.
+ *
+ * @param {string} translation - ICU format string (e.g., "<0>Click here</0>")
+ * @param {Array<Object>} [declarations=[]] - Array of component declarations matching tag numbers
+ * @returns {Array<React.ReactNode>} Array of React nodes (elements and text)
+ *
+ * @example
+ * ```jsx
+ * const result = renderTranslation(
+ *   "<0>bonjour</0> monde",
+ *   [{ type: 'strong', props: { className: 'bold' } }]
+ * );
+ * // Returns: [<strong className="bold">bonjour</strong>, " monde"]
+ * ```
+ *
+ * @example
+ * ```jsx
+ * // With nested children in declaration
+ * const result = renderTranslation(
+ *   "<0>Click <1>here</1></0>",
+ *   [
+ *     {
+ *       type: 'div',
+ *       props: {
+ *         children: [{ type: 'span', props: {} }]
+ *       }
+ *     }
+ *   ]
+ * );
+ * ```
+ */
+export const renderTranslation = (translation, declarations = []) => {
+  if (!translation) {
+    return [];
+  }
+
+  const tokens = tokenize(translation);
+  const result = [];
+  const stack = [];
+
+  // Track tag numbers that should be treated as literal text (no declaration found)
+  const literalTagNumbers = new Set();
+
+  // Helper to get the current declarations array based on context
+  const getCurrentDeclarations = () => {
+    if (stack.length === 0) {
+      return declarations;
+    }
+
+    const parentFrame = stack[stack.length - 1];
+
+    // If the parent declaration has children declarations, use those
+    if (
+      parentFrame.declaration.props?.children &&
+      Array.isArray(parentFrame.declaration.props.children)
+    ) {
+      return parentFrame.declaration.props.children;
+    }
+
+    // Otherwise, use the parent's declarations array
+    return parentFrame.declarations;
+  };
+
+  tokens.forEach((token) => {
+    // eslint-disable-next-line default-case
+    switch (token.type) {
+      case 'Text':
+        {
+          const decoded = decodeHtmlEntities(token.value);
+          const targetArray = stack.length > 0 ? stack[stack.length - 1].children : result;
+
+          targetArray.push(decoded);
+        }
+
+        break;
+
+      case 'TagOpen':
+        {
+          const { tagNumber } = token;
+          const currentDeclarations = getCurrentDeclarations();
+          const declaration = currentDeclarations[tagNumber];
+
+          if (!declaration) {
+            // No declaration found - treat this tag as literal text
+            literalTagNumbers.add(tagNumber);
+
+            const literalText = `<${tagNumber}>`;
+            const targetArray = stack.length > 0 ? stack[stack.length - 1].children : result;
+
+            targetArray.push(literalText);
+
+            break;
+          }
+
+          stack.push({
+            tagNumber,
+            children: [],
+            position: token.position,
+            declaration,
+            declarations: currentDeclarations,
+          });
+        }
+
+        break;
+
+      case 'TagClose':
+        {
+          const { tagNumber } = token;
+
+          // If this tag was treated as literal, output the closing tag as literal text
+          if (literalTagNumbers.has(tagNumber)) {
+            const literalText = `</${tagNumber}>`;
+            const literalTargetArray = stack.length > 0 ? stack[stack.length - 1].children : result;
+
+            literalTargetArray.push(literalText);
+
+            literalTagNumbers.delete(tagNumber);
+
+            break;
+          }
+
+          if (stack.length === 0) {
+            throw new TranslationParserError(
+              `Unexpected closing tag </${tagNumber}> at position ${token.position}`,
+              token.position,
+              translation,
+            );
+          }
+
+          const frame = stack.pop();
+
+          if (frame.tagNumber !== tagNumber) {
+            throw new TranslationParserError(
+              `Mismatched tags: expected </${frame.tagNumber}> but got </${tagNumber}> at position ${token.position}`,
+              token.position,
+              translation,
+            );
+          }
+
+          // Render the element using the declaration and collected children
+          const element = renderDeclarationNode(
+            frame.declaration,
+            frame.children,
+            frame.declarations,
+          );
+
+          const elementTargetArray = stack.length > 0 ? stack[stack.length - 1].children : result;
+
+          elementTargetArray.push(element);
+        }
+
+        break;
+    }
+  });
+
+  if (stack.length > 0) {
+    const unclosed = stack[stack.length - 1];
+
+    throw new TranslationParserError(
+      `Unclosed tag <${unclosed.tagNumber}> at position ${unclosed.position}`,
+      unclosed.position,
+      translation,
+    );
+  }
+
+  return result;
+};

--- a/src/IcuTransUtils/tokenizer.js
+++ b/src/IcuTransUtils/tokenizer.js
@@ -1,0 +1,78 @@
+/**
+ * Tokenize a translation string with numbered tags
+ * Note: Variables are already interpolated by the i18n system before we receive the string
+ *
+ * @param {string} translation - Translation string with numbered tags
+ * @returns {Array<Token>} Array of tokens
+ */
+export const tokenize = (translation) => {
+  const tokens = [];
+
+  let position = 0;
+
+  let currentText = '';
+
+  const flushText = () => {
+    if (currentText) {
+      tokens.push({
+        type: 'Text',
+        value: currentText,
+        position: position - currentText.length,
+      });
+
+      currentText = '';
+    }
+  };
+
+  while (position < translation.length) {
+    const char = translation[position];
+
+    // Check for opening tag: <0>, <1>, etc.
+    if (char === '<') {
+      const tagMatch = translation.slice(position).match(/^<(\d+)>/);
+
+      if (tagMatch) {
+        flushText();
+
+        tokens.push({
+          type: 'TagOpen',
+          value: tagMatch[0],
+          position,
+          tagNumber: parseInt(tagMatch[1], 10),
+        });
+
+        position += tagMatch[0].length;
+      } else {
+        // Check for closing tag: </0>, </1>, etc.
+        const closeTagMatch = translation.slice(position).match(/^<\/(\d+)>/);
+
+        if (closeTagMatch) {
+          flushText();
+
+          tokens.push({
+            type: 'TagClose',
+            value: closeTagMatch[0],
+            position,
+            tagNumber: parseInt(closeTagMatch[1], 10),
+          });
+
+          position += closeTagMatch[0].length;
+        } else {
+          // Regular text (including any { } characters that aren't our tags)
+          currentText += char;
+
+          position += 1;
+        }
+      }
+    } else {
+      // Regular text (including any { } characters that aren't our tags)
+      currentText += char;
+
+      position += 1;
+    }
+  }
+
+  flushText();
+
+  return tokens;
+};

--- a/src/IcuTransWithoutContext.js
+++ b/src/IcuTransWithoutContext.js
@@ -1,0 +1,146 @@
+import React from 'react';
+import { warn, warnOnce, isString } from './utils.js';
+import { getI18n } from './i18nInstance.js';
+import { renderTranslation } from './IcuTransUtils';
+
+/**
+ * IcuTrans component for rendering ICU MessageFormat translations (without React Context)
+ *
+ * This is the core implementation without React hooks or context dependencies,
+ * making it suitable for use in any environment. It uses a declaration tree
+ * approach where components are defined as type + props blueprints, fetches
+ * the translated string via i18next, and reconstructs the React element tree
+ * by replacing numbered tags (<0>, <1>) with actual components.
+ *
+ * Key features:
+ * - No React hooks or context (can be used anywhere)
+ * - ICU MessageFormat compatible
+ * - Supports nested component declarations
+ * - Automatic HTML entity decoding
+ * - Graceful error handling with fallbacks
+ * - Merges default interpolation variables
+ *
+ * Note: Users should typically use the IcuTrans export which provides automatic
+ * context support. This component is exposed for advanced use cases where direct
+ * i18n instance control is needed, or for use outside of React Context.
+ *
+ * @param {Object} props - Component props
+ * @param {string} props.i18nKey - The i18n key to look up the translation
+ * @param {string} props.defaultTranslation - The default translation in ICU format with numbered tags (e.g., "<0>Click here</0>")
+ * @param {Array<{type: string|React.ComponentType, props?: Object}>} props.content - Declaration tree describing React components and their props
+ * @param {string|string[]} [props.ns] - Optional namespace(s) for the translation. Falls back to t.ns, then i18n.options.defaultNS, then 'translation'
+ * @param {Object} [props.values={}] - Optional values for ICU variable interpolation (merged with i18n.options.interpolation.defaultVariables if present)
+ * @param {Object} [props.i18n] - i18next instance. If not provided, uses global instance from getI18n()
+ * @param {Function} [props.t] - Custom translation function. If not provided, uses i18n.t.bind(i18n)
+ * @returns {React.ReactElement} React fragment containing the rendered translation
+ *
+ * @example
+ * ```jsx
+ * // Direct usage with i18n instance
+ * <IcuTransWithoutContext
+ *   i18nKey="welcome.message"
+ *   defaultTranslation="Welcome <0>back</0>!"
+ *   content={[
+ *     { type: 'strong', props: { className: 'highlight' } }
+ *   ]}
+ *   i18n={i18nInstance}
+ * />
+ * ```
+ *
+ * @example
+ * ```jsx
+ * // With nested declarations for list rendering
+ * <IcuTransWithoutContext
+ *   i18nKey="features.list"
+ *   defaultTranslation="Features: <0><0>Fast</0><1>Reliable</1><2>Secure</2></0>"
+ *   content={[
+ *     {
+ *       type: 'ul',
+ *       props: {
+ *         children: [
+ *           { type: 'li', props: {} },
+ *           { type: 'li', props: {} },
+ *           { type: 'li', props: {} }
+ *         ]
+ *       }
+ *     }
+ *   ]}
+ *   i18n={i18nInstance}
+ * />
+ * ```
+ *
+ * @example
+ * ```jsx
+ * // With values for ICU variable interpolation
+ * <IcuTransWithoutContext
+ *   i18nKey="greeting"
+ *   defaultTranslation="Hello <0>{name}</0>!"
+ *   content={[{ type: 'strong', props: {} }]}
+ *   values={{ name: 'Alice' }}
+ *   i18n={i18nInstance}
+ * />
+ * ```
+ */
+export function IcuTransWithoutContext({
+  i18nKey,
+  defaultTranslation,
+  content,
+  ns,
+  values = {},
+  i18n: i18nFromProps,
+  t: tFromProps,
+}) {
+  const i18n = i18nFromProps || getI18n();
+
+  if (!i18n) {
+    warnOnce(
+      i18n,
+      'NO_I18NEXT_INSTANCE',
+      `IcuTrans: You need to pass in an i18next instance using i18nextReactModule`,
+      { i18nKey },
+    );
+    return React.createElement(React.Fragment, {}, defaultTranslation);
+  }
+
+  const t = tFromProps || i18n.t?.bind(i18n) || ((k) => k);
+
+  // prepare having a namespace
+  let namespaces = ns || t.ns || i18n.options?.defaultNS;
+  namespaces = isString(namespaces) ? [namespaces] : namespaces || ['translation'];
+
+  // Merge default interpolation variables if they exist
+  let mergedValues = values;
+  if (i18n.options?.interpolation?.defaultVariables) {
+    mergedValues =
+      values && Object.keys(values).length > 0
+        ? { ...values, ...i18n.options.interpolation.defaultVariables }
+        : { ...i18n.options.interpolation.defaultVariables };
+  }
+
+  // Get the translation, falling back to defaultTranslation
+  const translation = t(i18nKey, {
+    defaultValue: defaultTranslation,
+    ...mergedValues,
+    ns: namespaces,
+  });
+
+  // Render the translation with the declaration tree
+  try {
+    const rendered = renderTranslation(translation, content);
+
+    // Return as a React fragment to avoid extra wrapper
+    return React.createElement(React.Fragment, {}, ...rendered);
+  } catch (error) {
+    // If rendering fails, warn and fall back to the translation string
+    warn(
+      i18n,
+      'ICU_TRANS_RENDER_ERROR',
+      `IcuTrans component error for key "${i18nKey}": ${error.message}`,
+      { i18nKey, error },
+    );
+
+    return React.createElement(React.Fragment, {}, translation);
+  }
+}
+
+IcuTransWithoutContext.displayName = 'IcuTransWithoutContext';

--- a/test/IcuTrans/IcuTrans.spec.jsx
+++ b/test/IcuTrans/IcuTrans.spec.jsx
@@ -1,0 +1,852 @@
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import { I18nextProvider } from '../../src/I18nextProvider';
+import { IcuTrans } from '../../src/IcuTrans';
+import i18n from '../i18n';
+
+describe('IcuTrans', () => {
+  beforeAll(async () => {
+    await i18n.init();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe('basic rendering', () => {
+    it('should render plain text without tags', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans i18nKey="test.plain" defaultTranslation="Hello World" content={[]} />
+        </I18nextProvider>,
+      );
+
+      expect(container.textContent).toBe('Hello World');
+    });
+
+    it('should render text with a single tag', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="test.single"
+            defaultTranslation="Click <0>here</0> to continue"
+            content={[{ type: 'strong', props: {} }]}
+          />
+        </I18nextProvider>,
+      );
+
+      expect(container.innerHTML).toContain('<strong>here</strong>');
+      expect(container.textContent).toBe('Click here to continue');
+    });
+
+    it('should render text with multiple tags', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="test.multiple"
+            defaultTranslation="Text with <0>bold</0> and <1>italic</1>"
+            content={[
+              { type: 'strong', props: {} },
+              { type: 'em', props: {} },
+            ]}
+          />
+        </I18nextProvider>,
+      );
+
+      expect(container.innerHTML).toContain('<strong>bold</strong>');
+      expect(container.innerHTML).toContain('<em>italic</em>');
+      expect(container.textContent).toBe('Text with bold and italic');
+    });
+
+    it('should render nested tags', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="test.nested"
+            defaultTranslation="<0>Outer <1>inner</1> text</0>"
+            content={[
+              { type: 'div', props: {} },
+              { type: 'strong', props: {} },
+            ]}
+          />
+        </I18nextProvider>,
+      );
+
+      expect(container.innerHTML).toContain('<div>');
+      expect(container.innerHTML).toContain('<strong>inner</strong>');
+      expect(container.textContent).toBe('Outer inner text');
+    });
+  });
+
+  describe('component props', () => {
+    it('should preserve component props', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="test.props"
+            defaultTranslation="Go <0>here</0>"
+            content={[{ type: 'a', props: { href: '/test', className: 'link' } }]}
+          />
+        </I18nextProvider>,
+      );
+
+      const link = container.querySelector('a');
+      expect(link).toBeTruthy();
+      expect(link.getAttribute('href')).toBe('/test');
+      expect(link.getAttribute('class')).toBe('link');
+      expect(link.textContent).toBe('here');
+    });
+
+    it('should support data attributes', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="test.data"
+            defaultTranslation="Click <0>button</0>"
+            content={[{ type: 'button', props: { 'data-testid': 'btn', 'data-action': 'submit' } }]}
+          />
+        </I18nextProvider>,
+      );
+
+      const button = container.querySelector('button');
+      expect(button.getAttribute('data-testid')).toBe('btn');
+      expect(button.getAttribute('data-action')).toBe('submit');
+    });
+
+    it('should support event handlers in props', () => {
+      const handleClick = vi.fn();
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="test.events"
+            defaultTranslation="Click <0>me</0>"
+            content={[{ type: 'button', props: { onClick: handleClick } }]}
+          />
+        </I18nextProvider>,
+      );
+
+      const button = container.querySelector('button');
+      button.click();
+      expect(handleClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('React components', () => {
+    it('should render custom React components', () => {
+      function CustomButton({ children, color }) {
+        return (
+          <button type="button" style={{ color }}>
+            {children}
+          </button>
+        );
+      }
+
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="test.custom"
+            defaultTranslation="Click <0>here</0>"
+            content={[{ type: CustomButton, props: { color: 'red' } }]}
+          />
+        </I18nextProvider>,
+      );
+
+      const button = container.querySelector('button');
+      expect(button).toBeTruthy();
+      expect(button.style.color).toBe('red');
+      expect(button.textContent).toBe('here');
+    });
+
+    it('should render self-closing components', () => {
+      function Icon({ name }) {
+        return <i className={`icon-${name}`} />;
+      }
+
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="test.icon"
+            defaultTranslation="Documentation <0></0>"
+            content={[{ type: Icon, props: { name: 'external' } }]}
+          />
+        </I18nextProvider>,
+      );
+
+      const icon = container.querySelector('i');
+      expect(icon).toBeTruthy();
+      expect(icon.className).toBe('icon-external');
+    });
+  });
+
+  describe('interpolation values', () => {
+    it('should support variable interpolation', () => {
+      // Note: In real usage, i18n would handle interpolation before IcuTrans receives it
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="test.interpolation"
+            defaultTranslation="Hello World"
+            content={[]}
+            values={{ name: 'World' }}
+          />
+        </I18nextProvider>,
+      );
+
+      expect(container.textContent).toBeTruthy();
+    });
+
+    it('should pass values to i18n t function', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="test.values"
+            defaultTranslation="Count: <0>5</0> items"
+            content={[{ type: 'strong', props: {} }]}
+            values={{ count: 5 }}
+          />
+        </I18nextProvider>,
+      );
+
+      expect(container.textContent).toBeTruthy();
+    });
+  });
+
+  describe('HTML entities', () => {
+    it('should decode HTML entities in translations', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="test.entities"
+            defaultTranslation="&copy; 2024 &amp; <0>more</0>"
+            content={[{ type: 'strong', props: {} }]}
+          />
+        </I18nextProvider>,
+      );
+
+      expect(container.textContent).toContain('©');
+      expect(container.textContent).toContain('&');
+      expect(container.textContent).toContain('more');
+    });
+
+    it('should decode entities in nested content', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="test.nested.entities"
+            defaultTranslation="<0>Price: &euro;50 &ndash; &euro;100</0>"
+            content={[{ type: 'span', props: {} }]}
+          />
+        </I18nextProvider>,
+      );
+
+      expect(container.textContent).toContain('€50');
+      expect(container.textContent).toContain('€100');
+      expect(container.textContent).toContain('–');
+    });
+  });
+
+  describe('namespaces', () => {
+    it('should support single namespace', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="test.ns"
+            defaultTranslation="Namespace test"
+            content={[]}
+            ns="translation"
+          />
+        </I18nextProvider>,
+      );
+
+      expect(container.textContent).toBeTruthy();
+    });
+
+    it('should support multiple namespaces', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="test.ns.array"
+            defaultTranslation="Multi namespace"
+            content={[]}
+            ns={['common', 'translation']}
+          />
+        </I18nextProvider>,
+      );
+
+      expect(container.textContent).toBeTruthy();
+    });
+  });
+
+  describe('complex scenarios', () => {
+    it('should handle deeply nested structures', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="test.deep"
+            defaultTranslation="<0><1><2>Deep nesting</2></1></0>"
+            content={[
+              { type: 'div', props: {} },
+              { type: 'span', props: {} },
+              { type: 'strong', props: {} },
+            ]}
+          />
+        </I18nextProvider>,
+      );
+
+      expect(container.innerHTML).toContain('<div>');
+      expect(container.innerHTML).toContain('<span>');
+      expect(container.innerHTML).toContain('<strong>Deep nesting</strong>');
+    });
+
+    it('should handle mixed content with text and components', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="test.mixed"
+            defaultTranslation="Start <0>bold</0> middle <1>italic</1> end"
+            content={[
+              { type: 'strong', props: {} },
+              { type: 'em', props: {} },
+            ]}
+          />
+        </I18nextProvider>,
+      );
+
+      expect(container.textContent).toBe('Start bold middle italic end');
+      expect(container.innerHTML).toContain('<strong>bold</strong>');
+      expect(container.innerHTML).toContain('<em>italic</em>');
+    });
+
+    it('should handle multiple uses of the same tag number', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="test.reuse"
+            defaultTranslation="<0>First</0> and <0>second</0>"
+            content={[{ type: 'strong', props: {} }]}
+          />
+        </I18nextProvider>,
+      );
+
+      const strongs = container.querySelectorAll('strong');
+      expect(strongs).toHaveLength(2);
+      expect(strongs[0].textContent).toBe('First');
+      expect(strongs[1].textContent).toBe('second');
+    });
+
+    it('should handle adjacent tags without text between', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="test.adjacent"
+            defaultTranslation="<0>First</0><1>Second</1>"
+            content={[
+              { type: 'span', props: {} },
+              { type: 'strong', props: {} },
+            ]}
+          />
+        </I18nextProvider>,
+      );
+
+      expect(container.innerHTML).toContain('<span>First</span>');
+      expect(container.innerHTML).toContain('<strong>Second</strong>');
+      expect(container.textContent).toBe('FirstSecond');
+    });
+
+    it('should handle tags with only whitespace', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="test.whitespace"
+            defaultTranslation="<0>  </0>"
+            content={[{ type: 'span', props: {} }]}
+          />
+        </I18nextProvider>,
+      );
+
+      const span = container.querySelector('span');
+      expect(span).toBeTruthy();
+      expect(span.textContent).toBe('  ');
+    });
+  });
+
+  describe('nested children in declarations', () => {
+    it('should handle nested children declarations', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="test.nested.decl"
+            defaultTranslation="<0><0>Item 1</0><1>Item 2</1></0>"
+            content={[
+              {
+                type: 'ul',
+                props: {
+                  children: [
+                    { type: 'li', props: {} },
+                    { type: 'li', props: {} },
+                  ],
+                },
+              },
+            ]}
+          />
+        </I18nextProvider>,
+      );
+
+      const ul = container.querySelector('ul');
+      expect(ul).toBeTruthy();
+      const lis = ul.querySelectorAll('li');
+      expect(lis).toHaveLength(2);
+      expect(lis[0].textContent).toBe('Item 1');
+      expect(lis[1].textContent).toBe('Item 2');
+    });
+
+    it('should handle nested declarations with different depths', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="test.complex.nested"
+            defaultTranslation="<0>Text and <0>nested code</0></0>"
+            content={[
+              {
+                type: 'div',
+                props: {
+                  style: { padding: '10px' },
+                  children: [{ type: 'code', props: {} }],
+                },
+              },
+            ]}
+          />
+        </I18nextProvider>,
+      );
+
+      const div = container.querySelector('div');
+      expect(div).toBeTruthy();
+      expect(div.style.padding).toBe('10px');
+      const code = div.querySelector('code');
+      expect(code).toBeTruthy();
+      expect(code.textContent).toBe('nested code');
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle rendering errors gracefully with mismatched tags', () => {
+      // Force an error by providing mismatched tags - renderTranslation will throw
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="test.error.mismatched"
+            defaultTranslation="<0>Text</1>"
+            content={[{ type: 'div', props: {} }]}
+          />
+        </I18nextProvider>,
+      );
+
+      // Should fallback to showing the translation string when error occurs
+      expect(container.textContent).toBe('<0>Text</1>');
+    });
+
+    it('should handle missing translation key', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="nonexistent.key"
+            defaultTranslation="Fallback <0>text</0>"
+            content={[{ type: 'strong', props: {} }]}
+          />
+        </I18nextProvider>,
+      );
+
+      // Should use defaultTranslation
+      expect(container.textContent).toBe('Fallback text');
+    });
+
+    it('should handle empty content array', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans i18nKey="test.empty" defaultTranslation="No components" content={[]} />
+        </I18nextProvider>,
+      );
+
+      expect(container.textContent).toBe('No components');
+    });
+
+    it('should handle missing declarations for tags', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="test.missing"
+            defaultTranslation="<0>text</0> and <1>more</1>"
+            content={[{ type: 'strong', props: {} }]} // Only one declaration for two tags
+          />
+        </I18nextProvider>,
+      );
+
+      // Should render first tag correctly
+      expect(container.innerHTML).toContain('<strong>text</strong>');
+      // Second tag should be treated as literal text
+      expect(container.textContent).toContain('and');
+      expect(container.textContent).toContain('more');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty translation', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans i18nKey="test.empty.trans" defaultTranslation="" content={[]} />
+        </I18nextProvider>,
+      );
+
+      expect(container.textContent).toBe('');
+    });
+
+    it('should handle translation with only tags', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="test.only.tags"
+            defaultTranslation="<0></0><1></1>"
+            content={[
+              { type: 'span', props: { className: 'a' } },
+              { type: 'span', props: { className: 'b' } },
+            ]}
+          />
+        </I18nextProvider>,
+      );
+
+      const spans = container.querySelectorAll('span');
+      expect(spans).toHaveLength(2);
+      expect(spans[0].className).toBe('a');
+      expect(spans[1].className).toBe('b');
+    });
+
+    it('should handle Unicode characters', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="test.unicode"
+            defaultTranslation="Hello 世界 <0>🌍</0>"
+            content={[{ type: 'span', props: {} }]}
+          />
+        </I18nextProvider>,
+      );
+
+      expect(container.textContent).toContain('世界');
+      expect(container.textContent).toContain('🌍');
+    });
+
+    it('should handle special characters', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="test.special"
+            defaultTranslation="Test: <0>$100 + 50% = $150</0>"
+            content={[{ type: 'code', props: {} }]}
+          />
+        </I18nextProvider>,
+      );
+
+      expect(container.textContent).toBe('Test: $100 + 50% = $150');
+    });
+
+    it('should preserve whitespace', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="test.whitespace.preserve"
+            defaultTranslation="Text   with   <0>multiple   spaces</0>"
+            content={[{ type: 'span', props: {} }]}
+          />
+        </I18nextProvider>,
+      );
+
+      expect(container.textContent).toContain('   ');
+      expect(container.textContent).toContain('multiple   spaces');
+    });
+
+    it('should handle newlines', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="test.newlines"
+            defaultTranslation="Line 1\nLine 2\n<0>Line 3</0>"
+            content={[{ type: 'div', props: {} }]}
+          />
+        </I18nextProvider>,
+      );
+
+      expect(container.textContent).toContain('Line 1');
+      expect(container.textContent).toContain('Line 2');
+      expect(container.textContent).toContain('Line 3');
+    });
+  });
+
+  describe('real-world examples', () => {
+    it('should render a link with icon', () => {
+      function Icon({ name }) {
+        return <i className={`icon-${name}`} />;
+      }
+
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="docs.link"
+            defaultTranslation="See <0>documentation <1></1></0> for details"
+            content={[
+              { type: 'a', props: { href: '#docs' } },
+              { type: Icon, props: { name: 'external' } },
+            ]}
+          />
+        </I18nextProvider>,
+      );
+
+      const link = container.querySelector('a');
+      expect(link).toBeTruthy();
+      expect(link.getAttribute('href')).toBe('#docs');
+      expect(link.textContent).toContain('documentation');
+
+      const icon = link.querySelector('i');
+      expect(icon).toBeTruthy();
+      expect(icon.className).toBe('icon-external');
+    });
+
+    it('should render formatted text', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="format.text"
+            defaultTranslation="Welcome to <0>React</0>! It's <1>amazing</1>."
+            content={[
+              { type: 'strong', props: { style: { color: 'blue' } } },
+              { type: 'em', props: {} },
+            ]}
+          />
+        </I18nextProvider>,
+      );
+
+      const strong = container.querySelector('strong');
+      expect(strong).toBeTruthy();
+      expect(strong.style.color).toBe('blue');
+      expect(strong.textContent).toBe('React');
+
+      const em = container.querySelector('em');
+      expect(em).toBeTruthy();
+      expect(em.textContent).toBe('amazing');
+    });
+
+    it('should render copyright notice', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="footer.copyright"
+            defaultTranslation="&copy; 2024 <0>Company Name</0>. All rights reserved&reg;."
+            content={[{ type: 'strong', props: {} }]}
+          />
+        </I18nextProvider>,
+      );
+
+      expect(container.textContent).toContain('©');
+      expect(container.textContent).toContain('Company Name');
+      expect(container.textContent).toContain('®');
+    });
+
+    it('should render call-to-action', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="cta.signup"
+            defaultTranslation="Ready to start? <0>Sign up now</0> and get 50% off!"
+            content={[{ type: 'a', props: { href: '/signup', className: 'btn btn-primary' } }]}
+          />
+        </I18nextProvider>,
+      );
+
+      const link = container.querySelector('a');
+      expect(link).toBeTruthy();
+      expect(link.getAttribute('href')).toBe('/signup');
+      expect(link.className).toContain('btn');
+      expect(link.textContent).toBe('Sign up now');
+    });
+  });
+
+  describe('displayName', () => {
+    it('should have correct displayName', () => {
+      expect(IcuTrans.displayName).toBe('IcuTrans');
+    });
+  });
+
+  describe('deeply nested complex scenario with ICU MessageFormat', () => {
+    it('should handle complex ICU translation with plural, select, number, and date - scenario 1', () => {
+      // This will trigger: plural "other" branch and select "other" branch
+      const now = new Date(2025, 9, 13);
+      const count = 1;
+      const selectInput = 'other';
+      const numbers = 41;
+
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="examples.complex-trans"
+            defaultTranslation="<0>exciting!</0>{count, plural, =0 { hi there <1>friend</1> } other { woweee even supports nested {numbers, number} } } and {selectInput, select, thing { another nested thing <2>with regular text and a date: <0>{now, date}</0></2> } other {and the fallback <3><0>one</0><1>two</1></3>}}"
+            content={[
+              { type: 'strong' }, // <0>exciting!</0>
+              { type: 'strong' }, // <1>friend</1> (in plural =0 branch)
+              {
+                type: 'div',
+                props: {
+                  style: { color: 'red' },
+                  children: [
+                    { type: 'code' }, // <0> inside div - date display
+                  ],
+                },
+              }, // <2> (in select "thing" branch)
+              {
+                type: 'ul',
+                props: {
+                  children: [
+                    { type: 'li' }, // <0> inside ul
+                    { type: 'li' }, // <1> inside ul
+                  ],
+                },
+              }, // <3> (in select "other" branch)
+            ]}
+            values={{ count, numbers, selectInput, now }}
+          />
+        </I18nextProvider>,
+      );
+
+      // With the given values, ICU should process to:
+      // "<0>exciting!</0> woweee even supports nested {numbers} and the fallback <3><0>one</0><1>two</1></3>"
+      expect(container.textContent).toContain('exciting!');
+      expect(container.textContent).toContain('and the fallback');
+      const ul = container.querySelector('ul');
+      expect(ul).toBeTruthy();
+    });
+
+    it('should handle complex ICU translation - scenario 2: count=0 branch', () => {
+      // With count=0, this triggers the "=0" branch of plural
+      const now = new Date(2025, 9, 13);
+      const count = 0;
+      const selectInput = 'other';
+      const numbers = 41;
+
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="examples.complex-trans-zero"
+            defaultTranslation="<0>exciting!</0>{count, plural, =0 { hi there <1>friend</1> } other { woweee even supports nested {numbers, number} } } and {selectInput, select, thing { another nested thing <2>with regular text and a date: <0>{now, date}</0></2> } other {and the fallback <3><0>one</0><1>two</1></3>}}"
+            content={[
+              { type: 'strong' }, // <0>exciting!</0>
+              { type: 'strong' }, // <1>friend</1>
+              {
+                type: 'div',
+                props: {
+                  style: { color: 'red' },
+                  children: [{ type: 'code' }],
+                },
+              },
+              {
+                type: 'ul',
+                props: {
+                  children: [{ type: 'li' }, { type: 'li' }],
+                },
+              },
+            ]}
+            values={{ count, numbers, selectInput, now }}
+          />
+        </I18nextProvider>,
+      );
+
+      // With count=0, should show " hi there <1>friend</1> " in the plural part
+      expect(container.textContent).toContain('exciting!');
+      expect(container.textContent).toContain('hi there');
+      expect(container.textContent).toContain('friend');
+    });
+
+    it('should handle complex ICU translation - scenario 3: selectInput="thing" branch', () => {
+      // With selectInput="thing", this triggers the "thing" branch of select
+      const now = new Date(2025, 9, 13);
+      const count = 1;
+      const selectInput = 'thing';
+      const numbers = 41;
+
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="examples.complex-trans-thing"
+            defaultTranslation="<0>exciting!</0>{count, plural, =0 { hi there <1>friend</1> } other { woweee even supports nested {numbers, number} } } and {selectInput, select, thing { another nested thing <2>with regular text and a date: <0>{now, date}</0></2> } other {and the fallback <3><0>one</0><1>two</1></3>}}"
+            content={[
+              { type: 'strong' },
+              { type: 'strong' },
+              {
+                type: 'div',
+                props: {
+                  style: { color: 'red' },
+                  children: [{ type: 'code' }],
+                },
+              },
+              {
+                type: 'ul',
+                props: {
+                  children: [{ type: 'li' }, { type: 'li' }],
+                },
+              },
+            ]}
+            values={{ count, numbers, selectInput, now }}
+          />
+        </I18nextProvider>,
+      );
+
+      // With selectInput="thing", should show the div with nested code for date
+      expect(container.textContent).toContain('exciting!');
+      expect(container.textContent).toContain('another nested thing');
+      expect(container.textContent).toContain('with regular text and a date:');
+      const div = container.querySelector('div[style]');
+      expect(div).toBeTruthy();
+    });
+  });
+
+  describe('context handling', () => {
+    it('should work without I18nextProvider (using global instance)', () => {
+      // Test using the component outside of I18nextProvider
+      const { container } = render(
+        <IcuTrans
+          i18nKey="test.global"
+          defaultTranslation="Global <0>test</0>"
+          content={[{ type: 'strong', props: {} }]}
+          i18n={i18n}
+        />,
+      );
+
+      expect(container.textContent).toBe('Global test');
+    });
+
+    it('should use context when available', () => {
+      const { container } = render(
+        <I18nextProvider i18n={i18n}>
+          <IcuTrans
+            i18nKey="test.context"
+            defaultTranslation="Context <0>test</0>"
+            content={[{ type: 'em', props: {} }]}
+          />
+        </I18nextProvider>,
+      );
+
+      expect(container.textContent).toBe('Context test');
+    });
+
+    it('should handle missing i18n instance gracefully', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const { container } = render(
+        <IcuTrans i18nKey="test.no.i18n" defaultTranslation="Fallback text" content={[]} />,
+      );
+
+      // Should render the defaultTranslation
+      expect(container.textContent).toBe('Fallback text');
+
+      consoleWarnSpy.mockRestore();
+    });
+  });
+});

--- a/test/IcuTrans/IcuTransWithoutContext.spec.jsx
+++ b/test/IcuTrans/IcuTransWithoutContext.spec.jsx
@@ -1,0 +1,275 @@
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import React from 'react';
+import { render } from '@testing-library/react';
+import { IcuTransWithoutContext } from '../../src/IcuTransWithoutContext';
+import * as i18nInstanceModule from '../../src/i18nInstance';
+import i18n from '../i18n';
+
+describe('IcuTransWithoutContext', () => {
+  beforeAll(async () => {
+    await i18n.init();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('basic rendering with i18n prop', () => {
+    it('should render with i18n instance passed as prop', () => {
+      const { container } = render(
+        <IcuTransWithoutContext
+          i18nKey="test.plain"
+          defaultTranslation="Hello World"
+          content={[]}
+          i18n={i18n}
+        />,
+      );
+
+      expect(container.textContent).toBe('Hello World');
+    });
+
+    it('should render with components', () => {
+      const { container } = render(
+        <IcuTransWithoutContext
+          i18nKey="test.component"
+          defaultTranslation="Click <0>here</0>"
+          content={[{ type: 'strong', props: {} }]}
+          i18n={i18n}
+        />,
+      );
+
+      expect(container.innerHTML).toContain('<strong>here</strong>');
+    });
+  });
+
+  describe('missing i18n instance', () => {
+    it('should fallback to defaultTranslation when i18n is not available', () => {
+      // Mock getI18n to return undefined
+      vi.spyOn(i18nInstanceModule, 'getI18n').mockReturnValue(undefined);
+
+      const { container } = render(
+        <IcuTransWithoutContext
+          i18nKey="test.no.i18n"
+          defaultTranslation="Fallback text"
+          content={[]}
+        />,
+      );
+
+      // Should render the defaultTranslation
+      expect(container.textContent).toBe('Fallback text');
+    });
+
+    it('should render defaultTranslation as plain text when no i18n', () => {
+      // Mock getI18n to return undefined
+      vi.spyOn(i18nInstanceModule, 'getI18n').mockReturnValue(undefined);
+
+      const { container } = render(
+        <IcuTransWithoutContext
+          i18nKey="test.no.i18n.components"
+          defaultTranslation="Fallback with tags"
+          content={[{ type: 'strong', props: {} }]}
+        />,
+      );
+
+      // Should render just the defaultTranslation string (not parsed when no i18n)
+      expect(container.textContent).toBe('Fallback with tags');
+    });
+  });
+
+  describe('namespace handling', () => {
+    it('should use provided namespace string', () => {
+      const { container } = render(
+        <IcuTransWithoutContext
+          i18nKey="test.ns"
+          defaultTranslation="Namespace test"
+          content={[]}
+          ns="translation"
+          i18n={i18n}
+        />,
+      );
+
+      expect(container.textContent).toBeTruthy();
+    });
+
+    it('should use namespace array when provided', () => {
+      const { container } = render(
+        <IcuTransWithoutContext
+          i18nKey="test.ns.array"
+          defaultTranslation="Multi namespace"
+          content={[]}
+          ns={['common', 'translation']}
+          i18n={i18n}
+        />,
+      );
+
+      expect(container.textContent).toBeTruthy();
+    });
+
+    it('should fall back to translation namespace when ns is null/undefined', () => {
+      // Create i18n without defaultNS and t without ns
+      const mockI18n = {
+        t: vi.fn((key, opts) => opts.defaultValue),
+        options: {},
+      };
+
+      const { container } = render(
+        <IcuTransWithoutContext
+          i18nKey="test.no.ns"
+          defaultTranslation="No namespace"
+          content={[]}
+          ns={null}
+          i18n={mockI18n}
+        />,
+      );
+
+      expect(container.textContent).toBe('No namespace');
+      // Verify the t function was called with 'translation' namespace
+      expect(mockI18n.t).toHaveBeenCalledWith(
+        'test.no.ns',
+        expect.objectContaining({
+          ns: ['translation'],
+        }),
+      );
+    });
+
+    it('should use t.ns when available and no ns prop provided', () => {
+      const customT = vi.fn(() => 'Translation');
+      customT.ns = 'custom';
+
+      const { container } = render(
+        <IcuTransWithoutContext
+          i18nKey="test.t.ns"
+          defaultTranslation="Test"
+          content={[]}
+          i18n={i18n}
+          t={customT}
+        />,
+      );
+
+      expect(container.textContent).toBeTruthy();
+    });
+  });
+
+  describe('values and interpolation', () => {
+    it('should pass values to translation', () => {
+      const { container } = render(
+        <IcuTransWithoutContext
+          i18nKey="test.values"
+          defaultTranslation="Hello World"
+          content={[]}
+          values={{ name: 'World' }}
+          i18n={i18n}
+        />,
+      );
+
+      expect(container.textContent).toBeTruthy();
+    });
+
+    it('should merge default interpolation variables', () => {
+      // Create a custom i18n instance with default variables
+      const customI18n = i18n.cloneInstance({
+        interpolation: {
+          defaultVariables: {
+            appName: 'MyApp',
+            version: '1.0',
+          },
+        },
+      });
+
+      const { container } = render(
+        <IcuTransWithoutContext
+          i18nKey="test.default.vars"
+          defaultTranslation="Test"
+          content={[]}
+          values={{ custom: 'value' }}
+          i18n={customI18n}
+        />,
+      );
+
+      expect(container.textContent).toBeTruthy();
+    });
+
+    it('should use only default variables when no values provided', () => {
+      const customI18n = i18n.cloneInstance({
+        interpolation: {
+          defaultVariables: {
+            appName: 'MyApp',
+          },
+        },
+      });
+
+      const { container } = render(
+        <IcuTransWithoutContext
+          i18nKey="test.only.defaults"
+          defaultTranslation="Test"
+          content={[]}
+          i18n={customI18n}
+        />,
+      );
+
+      expect(container.textContent).toBeTruthy();
+    });
+  });
+
+  describe('custom t function', () => {
+    it('should use custom t function when provided', () => {
+      const customT = vi.fn(() => 'Custom translation');
+
+      const { container } = render(
+        <IcuTransWithoutContext
+          i18nKey="test.custom.t"
+          defaultTranslation="Default"
+          content={[]}
+          i18n={i18n}
+          t={customT}
+        />,
+      );
+
+      expect(customT).toHaveBeenCalled();
+      expect(container.textContent).toBe('Custom translation');
+    });
+
+    it('should use fallback t function when i18n.t is not available', () => {
+      // Create an i18n-like object without a t function
+      const mockI18n = {
+        options: {
+          defaultNS: 'translation',
+        },
+      };
+
+      const { container } = render(
+        <IcuTransWithoutContext
+          i18nKey="test.fallback.t"
+          defaultTranslation="Fallback key test"
+          content={[]}
+          i18n={mockI18n}
+        />,
+      );
+
+      // Should use the fallback t function `((k) => k)` which returns the key
+      expect(container.textContent).toBe('test.fallback.t');
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle rendering errors gracefully with mismatched tags', () => {
+      const { container } = render(
+        <IcuTransWithoutContext
+          i18nKey="test.error.mismatched"
+          defaultTranslation="<0>Text</1>"
+          content={[{ type: 'div', props: {} }]}
+          i18n={i18n}
+        />,
+      );
+
+      // Should fallback to showing the translation string when error occurs
+      expect(container.textContent).toBe('<0>Text</1>');
+    });
+  });
+
+  describe('displayName', () => {
+    it('should have correct displayName', () => {
+      expect(IcuTransWithoutContext.displayName).toBe('IcuTransWithoutContext');
+    });
+  });
+});

--- a/test/IcuTrans/utils/htmlEntityDecoder.spec.js
+++ b/test/IcuTrans/utils/htmlEntityDecoder.spec.js
@@ -1,0 +1,540 @@
+import { describe, it, expect } from 'vitest';
+import { decodeHtmlEntities } from '../../../src/IcuTransUtils';
+
+describe('htmlEntityDecoder', () => {
+  describe('basic entities', () => {
+    it('should decode &nbsp; to non-breaking space', () => {
+      expect(decodeHtmlEntities('hello&nbsp;world')).toBe('hello\u00A0world');
+    });
+
+    it('should decode &amp; to ampersand', () => {
+      expect(decodeHtmlEntities('Tom &amp; Jerry')).toBe('Tom & Jerry');
+    });
+
+    it('should decode &lt; to less than', () => {
+      expect(decodeHtmlEntities('5 &lt; 10')).toBe('5 < 10');
+    });
+
+    it('should decode &gt; to greater than', () => {
+      expect(decodeHtmlEntities('10 &gt; 5')).toBe('10 > 5');
+    });
+
+    it('should decode &quot; to double quote', () => {
+      expect(decodeHtmlEntities('He said &quot;hello&quot;')).toBe('He said "hello"');
+    });
+
+    it('should decode &apos; to single quote', () => {
+      expect(decodeHtmlEntities('It&apos;s working')).toBe("It's working");
+    });
+  });
+
+  describe('copyright and trademark entities', () => {
+    it('should decode &copy; to copyright symbol', () => {
+      expect(decodeHtmlEntities('&copy; 2024')).toBe('© 2024');
+    });
+
+    it('should decode &reg; to registered trademark', () => {
+      expect(decodeHtmlEntities('React&reg;')).toBe('React®');
+    });
+
+    it('should decode &trade; to trademark symbol', () => {
+      expect(decodeHtmlEntities('Product&trade;')).toBe('Product™');
+    });
+  });
+
+  describe('punctuation entities', () => {
+    it('should decode &hellip; to ellipsis', () => {
+      expect(decodeHtmlEntities('Wait&hellip;')).toBe('Wait…');
+    });
+
+    it('should decode &ndash; to en dash', () => {
+      expect(decodeHtmlEntities('pages 10&ndash;20')).toBe('pages 10–20');
+    });
+
+    it('should decode &mdash; to em dash', () => {
+      expect(decodeHtmlEntities('Hello&mdash;world')).toBe('Hello—world');
+    });
+
+    it('should decode &lsquo; and &rsquo; to curly single quotes', () => {
+      expect(decodeHtmlEntities('&lsquo;hello&rsquo;')).toBe('\u2018hello\u2019');
+    });
+
+    it('should decode &ldquo; and &rdquo; to curly double quotes', () => {
+      expect(decodeHtmlEntities('&ldquo;hello&rdquo;')).toBe('\u201Chello\u201D');
+    });
+
+    it('should decode &sbquo; to single low quote', () => {
+      expect(decodeHtmlEntities('&sbquo;test')).toBe('\u201Atest');
+    });
+
+    it('should decode &bdquo; to double low quote', () => {
+      expect(decodeHtmlEntities('&bdquo;test')).toBe('\u201Etest');
+    });
+
+    it('should decode &dagger; and &Dagger; to dagger symbols', () => {
+      expect(decodeHtmlEntities('Note&dagger; and Note&Dagger;')).toBe('Note† and Note‡');
+    });
+
+    it('should decode &bull; to bullet', () => {
+      expect(decodeHtmlEntities('&bull; Item')).toBe('• Item');
+    });
+
+    it('should decode &prime; and &Prime; to prime symbols', () => {
+      expect(decodeHtmlEntities('5&prime; 10&Prime;')).toBe('5′ 10″');
+    });
+
+    it('should decode &lsaquo; and &rsaquo; to angle quotes', () => {
+      expect(decodeHtmlEntities('&lsaquo;text&rsaquo;')).toBe('‹text›');
+    });
+
+    it('should decode &sect; to section sign', () => {
+      expect(decodeHtmlEntities('&sect; 1')).toBe('§ 1');
+    });
+
+    it('should decode &para; to paragraph sign', () => {
+      expect(decodeHtmlEntities('&para; Introduction')).toBe('¶ Introduction');
+    });
+
+    it('should decode &middot; to middle dot', () => {
+      expect(decodeHtmlEntities('A &middot; B')).toBe('A · B');
+    });
+  });
+
+  describe('space entities', () => {
+    it('should decode &ensp; to en space', () => {
+      expect(decodeHtmlEntities('A&ensp;B')).toBe('A\u2002B');
+    });
+
+    it('should decode &emsp; to em space', () => {
+      expect(decodeHtmlEntities('A&emsp;B')).toBe('A\u2003B');
+    });
+
+    it('should decode &thinsp; to thin space', () => {
+      expect(decodeHtmlEntities('A&thinsp;B')).toBe('A\u2009B');
+    });
+  });
+
+  describe('currency entities', () => {
+    it('should decode &euro; to euro symbol', () => {
+      expect(decodeHtmlEntities('Price: &euro;50')).toBe('Price: €50');
+    });
+
+    it('should decode &pound; to pound symbol', () => {
+      expect(decodeHtmlEntities('&pound;100')).toBe('£100');
+    });
+
+    it('should decode &yen; to yen symbol', () => {
+      expect(decodeHtmlEntities('&yen;1000')).toBe('¥1000');
+    });
+
+    it('should decode &cent; to cent symbol', () => {
+      expect(decodeHtmlEntities('99&cent;')).toBe('99¢');
+    });
+
+    it('should decode &curren; to currency symbol', () => {
+      expect(decodeHtmlEntities('&curren;100')).toBe('¤100');
+    });
+  });
+
+  describe('math symbols', () => {
+    it('should decode &times; to multiplication sign', () => {
+      expect(decodeHtmlEntities('5 &times; 3')).toBe('5 × 3');
+    });
+
+    it('should decode &divide; to division sign', () => {
+      expect(decodeHtmlEntities('10 &divide; 2')).toBe('10 ÷ 2');
+    });
+
+    it('should decode &minus; to minus sign', () => {
+      expect(decodeHtmlEntities('5 &minus; 3')).toBe('5 − 3');
+    });
+
+    it('should decode &plusmn; to plus-minus sign', () => {
+      expect(decodeHtmlEntities('&plusmn;5')).toBe('±5');
+    });
+
+    it('should decode &ne; to not equal', () => {
+      expect(decodeHtmlEntities('a &ne; b')).toBe('a ≠ b');
+    });
+
+    it('should decode &le; to less than or equal', () => {
+      expect(decodeHtmlEntities('x &le; 10')).toBe('x ≤ 10');
+    });
+
+    it('should decode &ge; to greater than or equal', () => {
+      expect(decodeHtmlEntities('x &ge; 5')).toBe('x ≥ 5');
+    });
+
+    it('should decode &asymp; to approximately equal', () => {
+      expect(decodeHtmlEntities('pi &asymp; 3.14')).toBe('pi ≈ 3.14');
+    });
+
+    it('should decode &equiv; to equivalent', () => {
+      expect(decodeHtmlEntities('a &equiv; b')).toBe('a ≡ b');
+    });
+
+    it('should decode &infin; to infinity', () => {
+      expect(decodeHtmlEntities('lim &rarr; &infin;')).toBe('lim → ∞');
+    });
+
+    it('should decode integral and sum symbols', () => {
+      expect(decodeHtmlEntities('&int; &sum; &prod;')).toBe('∫ ∑ ∏');
+    });
+
+    it('should decode &radic; to square root', () => {
+      expect(decodeHtmlEntities('&radic;2')).toBe('√2');
+    });
+
+    it('should decode &part; to partial derivative', () => {
+      expect(decodeHtmlEntities('&part;f')).toBe('∂f');
+    });
+
+    it('should decode &permil; to per mille', () => {
+      expect(decodeHtmlEntities('5&permil;')).toBe('5‰');
+    });
+
+    it('should decode &deg; to degree symbol', () => {
+      expect(decodeHtmlEntities('90&deg;')).toBe('90°');
+    });
+
+    it('should decode &micro; to micro symbol', () => {
+      expect(decodeHtmlEntities('5&micro;m')).toBe('5µm');
+    });
+  });
+
+  describe('arrow entities', () => {
+    it('should decode basic arrows', () => {
+      expect(decodeHtmlEntities('&larr; &uarr; &rarr; &darr;')).toBe('← ↑ → ↓');
+    });
+
+    it('should decode &harr; to left-right arrow', () => {
+      expect(decodeHtmlEntities('A &harr; B')).toBe('A ↔ B');
+    });
+
+    it('should decode &crarr; to carriage return arrow', () => {
+      expect(decodeHtmlEntities('Press &crarr;')).toBe('Press ↵');
+    });
+
+    it('should decode double arrows', () => {
+      expect(decodeHtmlEntities('&lArr; &uArr; &rArr; &dArr; &hArr;')).toBe('⇐ ⇑ ⇒ ⇓ ⇔');
+    });
+  });
+
+  describe('Greek letters - lowercase', () => {
+    it('should decode common lowercase Greek letters', () => {
+      expect(decodeHtmlEntities('&alpha; &beta; &gamma; &delta;')).toBe('α β γ δ');
+    });
+
+    it('should decode &epsilon; &zeta; &eta; &theta;', () => {
+      expect(decodeHtmlEntities('&epsilon; &zeta; &eta; &theta;')).toBe('ε ζ η θ');
+    });
+
+    it('should decode &iota; &kappa; &lambda; &mu;', () => {
+      expect(decodeHtmlEntities('&iota; &kappa; &lambda; &mu;')).toBe('ι κ λ μ');
+    });
+
+    it('should decode &nu; &xi; &omicron; &pi;', () => {
+      expect(decodeHtmlEntities('&nu; &xi; &omicron; &pi;')).toBe('ν ξ ο π');
+    });
+
+    it('should decode &rho; &sigma; &tau; &upsilon;', () => {
+      expect(decodeHtmlEntities('&rho; &sigma; &tau; &upsilon;')).toBe('ρ σ τ υ');
+    });
+
+    it('should decode &phi; &chi; &psi; &omega;', () => {
+      expect(decodeHtmlEntities('&phi; &chi; &psi; &omega;')).toBe('φ χ ψ ω');
+    });
+  });
+
+  describe('Greek letters - uppercase', () => {
+    it('should decode common uppercase Greek letters', () => {
+      expect(decodeHtmlEntities('&Alpha; &Beta; &Gamma; &Delta;')).toBe('Α Β Γ Δ');
+    });
+
+    it('should decode &Epsilon; through &Theta;', () => {
+      expect(decodeHtmlEntities('&Epsilon; &Zeta; &Eta; &Theta;')).toBe('Ε Ζ Η Θ');
+    });
+
+    it('should decode &Sigma; &Phi; &Psi; &Omega;', () => {
+      expect(decodeHtmlEntities('&Sigma; &Phi; &Psi; &Omega;')).toBe('Σ Φ Ψ Ω');
+    });
+  });
+
+  describe('Latin extended - uppercase', () => {
+    it('should decode accented A variants', () => {
+      expect(decodeHtmlEntities('&Agrave; &Aacute; &Acirc; &Atilde; &Auml; &Aring;')).toBe(
+        'À Á Â Ã Ä Å',
+      );
+    });
+
+    it('should decode &AElig; and &Ccedil;', () => {
+      expect(decodeHtmlEntities('&AElig; &Ccedil;')).toBe('Æ Ç');
+    });
+
+    it('should decode accented E variants', () => {
+      expect(decodeHtmlEntities('&Egrave; &Eacute; &Ecirc; &Euml;')).toBe('È É Ê Ë');
+    });
+
+    it('should decode accented I variants', () => {
+      expect(decodeHtmlEntities('&Igrave; &Iacute; &Icirc; &Iuml;')).toBe('Ì Í Î Ï');
+    });
+
+    it('should decode &ETH; and &Ntilde;', () => {
+      expect(decodeHtmlEntities('&ETH; &Ntilde;')).toBe('Ð Ñ');
+    });
+
+    it('should decode accented O variants', () => {
+      expect(decodeHtmlEntities('&Ograve; &Oacute; &Ocirc; &Otilde; &Ouml; &Oslash;')).toBe(
+        'Ò Ó Ô Õ Ö Ø',
+      );
+    });
+
+    it('should decode accented U variants', () => {
+      expect(decodeHtmlEntities('&Ugrave; &Uacute; &Ucirc; &Uuml;')).toBe('Ù Ú Û Ü');
+    });
+
+    it('should decode &Yacute; and &THORN;', () => {
+      expect(decodeHtmlEntities('&Yacute; &THORN;')).toBe('Ý Þ');
+    });
+  });
+
+  describe('Latin extended - lowercase', () => {
+    it('should decode &szlig;', () => {
+      expect(decodeHtmlEntities('&szlig;')).toBe('ß');
+    });
+
+    it('should decode accented a variants', () => {
+      expect(decodeHtmlEntities('&agrave; &aacute; &acirc; &atilde; &auml; &aring;')).toBe(
+        'à á â ã ä å',
+      );
+    });
+
+    it('should decode &aelig; and &ccedil;', () => {
+      expect(decodeHtmlEntities('&aelig; &ccedil;')).toBe('æ ç');
+    });
+
+    it('should decode accented e variants', () => {
+      expect(decodeHtmlEntities('&egrave; &eacute; &ecirc; &euml;')).toBe('è é ê ë');
+    });
+
+    it('should decode accented i variants', () => {
+      expect(decodeHtmlEntities('&igrave; &iacute; &icirc; &iuml;')).toBe('ì í î ï');
+    });
+
+    it('should decode &eth; and &ntilde;', () => {
+      expect(decodeHtmlEntities('&eth; &ntilde;')).toBe('ð ñ');
+    });
+
+    it('should decode accented o variants', () => {
+      expect(decodeHtmlEntities('&ograve; &oacute; &ocirc; &otilde; &ouml; &oslash;')).toBe(
+        'ò ó ô õ ö ø',
+      );
+    });
+
+    it('should decode accented u variants', () => {
+      expect(decodeHtmlEntities('&ugrave; &uacute; &ucirc; &uuml;')).toBe('ù ú û ü');
+    });
+
+    it('should decode &yacute;, &thorn; and &yuml;', () => {
+      expect(decodeHtmlEntities('&yacute; &thorn; &yuml;')).toBe('ý þ ÿ');
+    });
+  });
+
+  describe('special characters', () => {
+    it('should decode &iexcl; and &iquest;', () => {
+      expect(decodeHtmlEntities('&iexcl; &iquest;')).toBe('¡ ¿');
+    });
+
+    it('should decode &fnof; to function symbol', () => {
+      expect(decodeHtmlEntities('f&fnof;(x)')).toBe('fƒ(x)');
+    });
+
+    it('should decode &circ; and &tilde;', () => {
+      expect(decodeHtmlEntities('&circ; &tilde;')).toBe('ˆ ˜');
+    });
+
+    it('should decode &OElig; and &oelig;', () => {
+      expect(decodeHtmlEntities('&OElig; &oelig;')).toBe('Œ œ');
+    });
+
+    it('should decode &Scaron;, &scaron; and &Yuml;', () => {
+      expect(decodeHtmlEntities('&Scaron; &scaron; &Yuml;')).toBe('Š š Ÿ');
+    });
+
+    it('should decode ordinal indicators', () => {
+      expect(decodeHtmlEntities('1&ordf; 2&ordm;')).toBe('1ª 2º');
+    });
+
+    it('should decode diacritical marks', () => {
+      expect(decodeHtmlEntities('&macr; &acute; &cedil;')).toBe('¯ ´ ¸');
+    });
+
+    it('should decode superscripts', () => {
+      expect(decodeHtmlEntities('x&sup1; x&sup2; x&sup3;')).toBe('x¹ x² x³');
+    });
+
+    it('should decode fractions', () => {
+      expect(decodeHtmlEntities('&frac14; &frac12; &frac34;')).toBe('¼ ½ ¾');
+    });
+  });
+
+  describe('card suits', () => {
+    it('should decode all card suit symbols', () => {
+      expect(decodeHtmlEntities('&spades; &clubs; &hearts; &diams;')).toBe('♠ ♣ ♥ ♦');
+    });
+  });
+
+  describe('miscellaneous symbols', () => {
+    it('should decode &loz; to lozenge', () => {
+      expect(decodeHtmlEntities('&loz;')).toBe('◊');
+    });
+
+    it('should decode mathematical script letters', () => {
+      expect(decodeHtmlEntities('&weierp; &image; &real; &alefsym;')).toBe('℘ ℑ ℜ ℵ');
+    });
+
+    it('should decode &oline; to overline', () => {
+      expect(decodeHtmlEntities('&oline;')).toBe('‾');
+    });
+
+    it('should decode &frasl; to fraction slash', () => {
+      expect(decodeHtmlEntities('1&frasl;2')).toBe('1⁄2');
+    });
+  });
+
+  describe('numeric entities', () => {
+    it('should decode decimal numeric entities', () => {
+      expect(decodeHtmlEntities('&#65;')).toBe('A');
+      expect(decodeHtmlEntities('&#169;')).toBe('©');
+      expect(decodeHtmlEntities('&#8230;')).toBe('…');
+    });
+
+    it('should decode hexadecimal numeric entities', () => {
+      expect(decodeHtmlEntities('&#x41;')).toBe('A');
+      expect(decodeHtmlEntities('&#xA9;')).toBe('©');
+      expect(decodeHtmlEntities('&#x2026;')).toBe('…');
+    });
+
+    it('should decode lowercase hex entities', () => {
+      expect(decodeHtmlEntities('&#x2f;')).toBe('/');
+      expect(decodeHtmlEntities('&#x3c;')).toBe('<');
+    });
+
+    it('should decode uppercase hex entities', () => {
+      expect(decodeHtmlEntities('&#x2F;')).toBe('/');
+      expect(decodeHtmlEntities('&#x3C;')).toBe('<');
+    });
+  });
+
+  describe('combined entities', () => {
+    it('should decode multiple entities in one string', () => {
+      const input = 'Tom &amp; Jerry &copy; 2024 &ndash; All rights reserved &trade;';
+      const expected = 'Tom & Jerry © 2024 – All rights reserved ™';
+      expect(decodeHtmlEntities(input)).toBe(expected);
+    });
+
+    it('should decode mixed named and numeric entities', () => {
+      const input = '&lt;div&gt;Hello &#8211; &#x201C;World&#x201D;&lt;/div&gt;';
+      const expected = '<div>Hello – \u201CWorld\u201D</div>';
+      expect(decodeHtmlEntities(input)).toBe(expected);
+    });
+
+    it('should handle entities at start, middle, and end', () => {
+      const input = '&copy; Start middle&nbsp;text end&trade;';
+      const expected = '© Start middle\u00A0text end™';
+      expect(decodeHtmlEntities(input)).toBe(expected);
+    });
+
+    it('should decode consecutive entities', () => {
+      const input = '&lt;&gt;&amp;&quot;&apos;';
+      const expected = '<>&"\'';
+      expect(decodeHtmlEntities(input)).toBe(expected);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should return empty string for empty input', () => {
+      expect(decodeHtmlEntities('')).toBe('');
+    });
+
+    it('should return unchanged string when no entities present', () => {
+      const input = 'Hello World 123';
+      expect(decodeHtmlEntities(input)).toBe(input);
+    });
+
+    it('should handle string with only entities', () => {
+      expect(decodeHtmlEntities('&amp;&lt;&gt;')).toBe('&<>');
+    });
+
+    it('should not decode incomplete entities', () => {
+      expect(decodeHtmlEntities('&amp test')).toBe('&amp test');
+      expect(decodeHtmlEntities('&lt test')).toBe('&lt test');
+    });
+
+    it('should not decode unknown entities', () => {
+      expect(decodeHtmlEntities('&unknown;')).toBe('&unknown;');
+    });
+
+    it('should handle malformed numeric entities', () => {
+      expect(decodeHtmlEntities('&#;')).toBe('&#;');
+      expect(decodeHtmlEntities('&#x;')).toBe('&#x;');
+    });
+
+    it('should preserve non-entity ampersands', () => {
+      expect(decodeHtmlEntities('A & B')).toBe('A & B');
+      expect(decodeHtmlEntities('Tom & Jerry')).toBe('Tom & Jerry');
+    });
+
+    it('should handle entities within words', () => {
+      expect(decodeHtmlEntities('It&apos;s&nbsp;working')).toBe("It's\u00A0working");
+    });
+
+    it('should handle Unicode characters mixed with entities', () => {
+      expect(decodeHtmlEntities('Hello 世界 &amp; &euro;50')).toBe('Hello 世界 & €50');
+    });
+
+    it('should handle very long strings with many entities', () => {
+      const input = Array(100).fill('&copy;').join(' ');
+      const expected = Array(100).fill('©').join(' ');
+      expect(decodeHtmlEntities(input)).toBe(expected);
+    });
+  });
+
+  describe('real-world examples', () => {
+    it('should decode a typical copyright notice', () => {
+      const input = '&copy; 2024 Company Name&trade;. All rights reserved&reg;.';
+      const expected = '© 2024 Company Name™. All rights reserved®.';
+      expect(decodeHtmlEntities(input)).toBe(expected);
+    });
+
+    it('should decode a mathematical expression', () => {
+      const input = 'E = mc&sup2;, &pi; &asymp; 3.14159';
+      const expected = 'E = mc², π ≈ 3.14159';
+      expect(decodeHtmlEntities(input)).toBe(expected);
+    });
+
+    it('should decode formatted quotes', () => {
+      const input = '&ldquo;Hello, World!&rdquo; he said.';
+      const expected = '\u201CHello, World!\u201D he said.';
+      expect(decodeHtmlEntities(input)).toBe(expected);
+    });
+
+    it('should decode HTML snippet', () => {
+      const input = '&lt;div class=&quot;container&quot;&gt;Content&lt;/div&gt;';
+      const expected = '<div class="container">Content</div>';
+      expect(decodeHtmlEntities(input)).toBe(expected);
+    });
+
+    it('should decode currency with symbols', () => {
+      const input = 'Price: &euro;99.99 or &pound;79.99 or &yen;10,000';
+      const expected = 'Price: €99.99 or £79.99 or ¥10,000';
+      expect(decodeHtmlEntities(input)).toBe(expected);
+    });
+
+    it('should decode temperature', () => {
+      const input = 'Temperature: 25&deg;C &plusmn; 2&deg;';
+      const expected = 'Temperature: 25°C ± 2°';
+      expect(decodeHtmlEntities(input)).toBe(expected);
+    });
+  });
+});

--- a/test/IcuTrans/utils/renderTranslation.spec.js
+++ b/test/IcuTrans/utils/renderTranslation.spec.js
@@ -1,0 +1,747 @@
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+
+import { TranslationParserError, renderTranslation } from '../../../src/IcuTransUtils';
+
+describe('translationParser', () => {
+  it('should render plain text without any tags', () => {
+    const result = renderTranslation('Hello world');
+
+    expect(result).toEqual(['Hello world']);
+  });
+
+  it('should render text with a single tag', () => {
+    const declarations = [{ type: 'strong', props: {} }];
+
+    const result = renderTranslation('<0>bold text</0>', declarations);
+
+    expect(result).toHaveLength(1);
+
+    expect(React.isValidElement(result[0])).toBe(true);
+
+    const element = result[0];
+
+    expect(element.type).toBe('strong');
+
+    expect(element.props.children).toBe('bold text');
+  });
+
+  it('should render tags with surrounding text content', () => {
+    const declarations = [{ type: 'a', props: { href: '#' } }];
+
+    const result = renderTranslation('Click <0>here</0> to continue', declarations);
+
+    expect(result).toHaveLength(3);
+
+    expect(result[0]).toBe('Click ');
+
+    expect(React.isValidElement(result[1])).toBe(true);
+
+    expect(result[2]).toBe(' to continue');
+
+    const link = result[1];
+
+    expect(link.type).toBe('a');
+
+    expect(link.props.href).toBe('#');
+
+    expect(link.props.children).toBe('here');
+  });
+
+  it('should render multiple tags in sequence', () => {
+    const declarations = [
+      { type: 'strong', props: {} },
+      { type: 'em', props: {} },
+    ];
+
+    const result = renderTranslation('<0>bold</0> and <1>italic</1>', declarations);
+
+    expect(result).toHaveLength(3);
+
+    expect(React.isValidElement(result[0])).toBe(true);
+
+    expect(result[1]).toBe(' and ');
+
+    expect(React.isValidElement(result[2])).toBe(true);
+
+    const bold = result[0];
+
+    expect(bold.type).toBe('strong');
+
+    expect(bold.props.children).toBe('bold');
+
+    const italic = result[2];
+
+    expect(italic.type).toBe('em');
+
+    expect(italic.props.children).toBe('italic');
+  });
+
+  it('should render nested tags with proper hierarchy', () => {
+    const declarations = [
+      { type: 'div', props: {} },
+      { type: 'strong', props: {} },
+    ];
+
+    const result = renderTranslation('<0>outer <1>inner</1> text</0>', declarations);
+
+    expect(result).toHaveLength(1);
+
+    const outer = result[0];
+
+    expect(outer.type).toBe('div');
+
+    expect(outer.props.children).toHaveLength(3);
+
+    expect(outer.props.children[0]).toBe('outer ');
+
+    const inner = outer.props.children[1];
+
+    expect(React.isValidElement(inner)).toBe(true);
+
+    expect(inner.type).toBe('strong');
+
+    expect(inner.props.children).toBe('inner');
+
+    expect(outer.props.children[2]).toBe(' text');
+  });
+
+  it('should preserve all component props from declarations', () => {
+    const declarations = [
+      {
+        type: 'a',
+        props: { href: '/test', className: 'link', 'data-test': 'foo' },
+      },
+    ];
+
+    const result = renderTranslation('<0>link</0>', declarations);
+
+    expect(result).toHaveLength(1);
+
+    const element = result[0];
+
+    expect(element.props.href).toBe('/test');
+
+    expect(element.props.className).toBe('link');
+
+    expect(element.props['data-test']).toBe('foo');
+
+    expect(element.props.children).toBe('link');
+  });
+
+  it('should handle deeply nested tag structures', () => {
+    const declarations = [
+      { type: 'div', props: {} },
+      { type: 'span', props: {} },
+      { type: 'strong', props: {} },
+    ];
+
+    const result = renderTranslation('<0><1><2>deep</2></1></0>', declarations);
+
+    expect(result).toHaveLength(1);
+
+    const div = result[0];
+
+    expect(div.type).toBe('div');
+
+    const span = div.props.children;
+
+    expect(span.type).toBe('span');
+
+    const strong = span.props.children;
+
+    expect(strong.type).toBe('strong');
+
+    expect(strong.props.children).toBe('deep');
+  });
+
+  it('should handle self-closing and empty tags', () => {
+    const declarations = [{ type: 'Icon', props: { name: 'test' } }];
+
+    const result = renderTranslation('Text <0></0> more text', declarations);
+
+    expect(result).toHaveLength(3);
+
+    expect(result[0]).toBe('Text ');
+
+    expect(React.isValidElement(result[1])).toBe(true);
+
+    expect(result[2]).toBe(' more text');
+
+    const icon = result[1];
+
+    expect(icon.type).toBe('Icon');
+
+    expect(icon.props.name).toBe('test');
+
+    expect(icon.props.children).toBeUndefined();
+  });
+
+  it('should decode HTML entities in text content', () => {
+    const declarations = [{ type: 'strong', props: {} }];
+
+    const result = renderTranslation('<0>me &amp; you &lt; 5</0>', declarations);
+
+    expect(result).toHaveLength(1);
+
+    const element = result[0];
+
+    expect(element.props.children).toBe('me & you < 5');
+  });
+
+  it('should decode non-breaking space entities correctly', () => {
+    const declarations = [{ type: 'span', props: {} }];
+
+    const result = renderTranslation('<0>hello&nbsp;world</0>', declarations);
+
+    expect(result).toHaveLength(1);
+
+    const element = result[0];
+
+    expect(element.props.children).toBe('hello\u00A0world');
+  });
+
+  it('should handle real-world translation with custom styling', () => {
+    const declarations = [{ type: 'div', props: { className: 'foo' } }];
+
+    const result = renderTranslation('<0>bonjour</0>', declarations);
+
+    expect(result).toHaveLength(1);
+
+    const element = result[0];
+
+    expect(element.type).toBe('div');
+
+    expect(element.props.className).toBe('foo');
+
+    expect(element.props.children).toBe('bonjour');
+  });
+
+  it('should handle real-world documentation link pattern with nested icon', () => {
+    const declarations = [
+      { type: 'a', props: { href: '#' } },
+      { type: 'Icon', props: { name: 'external-link' } },
+    ];
+
+    const result = renderTranslation(
+      'Voir <0>documentation <1></1></0> pour plus de détails.',
+      declarations,
+    );
+
+    expect(result).toHaveLength(3);
+
+    expect(result[0]).toBe('Voir ');
+
+    expect(React.isValidElement(result[1])).toBe(true);
+
+    expect(result[2]).toBe(' pour plus de détails.');
+
+    const link = result[1];
+
+    expect(link.type).toBe('a');
+
+    const linkChildren = React.Children.toArray(link.props.children);
+
+    expect(linkChildren).toHaveLength(2);
+
+    expect(linkChildren[0]).toBe('documentation ');
+
+    const icon = linkChildren[1];
+
+    expect(icon.type).toBe('Icon');
+
+    expect(icon.props.name).toBe('external-link');
+  });
+
+  it('should handle empty translation strings', () => {
+    const result = renderTranslation('');
+
+    expect(result).toEqual([]);
+  });
+
+  it('should preserve whitespace-only translations', () => {
+    const result = renderTranslation('   ');
+
+    expect(result).toEqual(['   ']);
+  });
+
+  it('should throw TranslationParserError for unexpected closing tags', () => {
+    expect(() => {
+      renderTranslation('Hello </0>', []);
+    }).toThrow(TranslationParserError);
+
+    expect(() => {
+      renderTranslation('Hello </0>', []);
+    }).toThrow('Unexpected closing tag');
+  });
+
+  it('should throw TranslationParserError for mismatched opening and closing tags', () => {
+    const declarations = [
+      { type: 'strong', props: {} },
+      { type: 'em', props: {} },
+    ];
+
+    expect(() => {
+      renderTranslation('<0>text</1>', declarations);
+    }).toThrow(TranslationParserError);
+
+    expect(() => {
+      renderTranslation('<0>text</1>', declarations);
+    }).toThrow('Mismatched tags');
+  });
+
+  it('should throw TranslationParserError for unclosed tags', () => {
+    const declarations = [{ type: 'strong', props: {} }];
+
+    expect(() => {
+      renderTranslation('<0>text', declarations);
+    }).toThrow(TranslationParserError);
+
+    expect(() => {
+      renderTranslation('<0>text', declarations);
+    }).toThrow('Unclosed tag');
+  });
+
+  it('should treat tags as literal text when declaration is missing', () => {
+    // Changed behavior: instead of throwing, treat missing declarations as literal text
+    const result = renderTranslation('<0>text</0>', []);
+
+    // The result will have the tag parts and text as separate array elements
+    expect(result).toEqual(['<0>', 'text', '</0>']);
+  });
+
+  it('should reuse the same declaration for multiple tags with identical numbers', () => {
+    const declarations = [{ type: 'strong', props: {} }];
+
+    const result = renderTranslation('<0>first</0> and <0>second</0>', declarations);
+
+    expect(result).toHaveLength(3);
+
+    expect(React.isValidElement(result[0])).toBe(true);
+
+    expect(result[1]).toBe(' and ');
+
+    expect(React.isValidElement(result[2])).toBe(true);
+
+    const first = result[0];
+
+    expect(first.type).toBe('strong');
+
+    expect(first.props.children).toBe('first');
+
+    const second = result[2];
+
+    expect(second.type).toBe('strong');
+
+    expect(second.props.children).toBe('second');
+  });
+
+  it('should pass through ICU variable placeholders without modification', () => {
+    const declarations = [{ type: 'strong', props: {} }];
+
+    const result = renderTranslation('<0>{userName}</0>', declarations);
+
+    expect(result).toHaveLength(1);
+
+    const element = result[0];
+
+    expect(element.props.children).toBe('{userName}');
+  });
+
+  it('should pass through complex ICU message syntax without modification', () => {
+    const declarations = [{ type: 'span', props: {} }];
+
+    const result = renderTranslation(
+      '<0>{count, plural, one {# item} other {# items}}</0>',
+      declarations,
+    );
+
+    expect(result).toHaveLength(1);
+
+    const element = result[0];
+
+    expect(element.props.children).toBe('{count, plural, one {# item} other {# items}}');
+  });
+
+  it('should render custom React component types from declarations', () => {
+    function CustomButton({ label }) {
+      return React.createElement('button', { type: 'button' }, label || 'Click');
+    }
+
+    const declarations = [{ type: CustomButton, props: { label: 'Custom' } }];
+
+    const result = renderTranslation('<0>text</0>', declarations);
+
+    expect(result).toHaveLength(1);
+
+    const element = result[0];
+
+    expect(element.type).toBe(CustomButton);
+
+    expect(element.props.label).toBe('Custom');
+
+    expect(element.props.children).toBe('text');
+  });
+
+  it('should handle declarations with pre-defined children prop structure', () => {
+    const declarations = [
+      {
+        type: 'div',
+        props: {
+          className: 'wrapper',
+          children: [{ type: 'span', props: { className: 'inner' } }],
+        },
+      },
+    ];
+
+    const result = renderTranslation('<0>text</0>', declarations);
+
+    expect(result).toHaveLength(1);
+
+    const element = result[0];
+
+    expect(element.type).toBe('div');
+
+    expect(element.props.className).toBe('wrapper');
+
+    expect(element.props.children).toBe('text');
+  });
+
+  it('should create TranslationParserError instances with all required properties', () => {
+    const error = new TranslationParserError('Test error', 10, 'test translation');
+
+    expect(error).toBeInstanceOf(Error);
+
+    expect(error).toBeInstanceOf(TranslationParserError);
+
+    expect(error.name).toBe('TranslationParserError');
+
+    expect(error.message).toBe('Test error');
+
+    expect(error.position).toBe(10);
+
+    expect(error.translationString).toBe('test translation');
+  });
+
+  it('should decode numeric HTML entities in both decimal and hexadecimal formats', () => {
+    const declarations = [{ type: 'span', props: {} }];
+
+    const result = renderTranslation('<0>&#65; &#x42;</0>', declarations);
+
+    expect(result).toHaveLength(1);
+
+    const element = result[0];
+
+    expect(element.props.children).toBe('A B');
+  });
+
+  it('should handle nested declarations containing children arrays for multi-level structures', () => {
+    const declarations = [
+      {
+        type: 'div',
+        props: {
+          style: { color: 'red' },
+          children: [
+            { type: 'code' }, // nested child that handles <0> inside parent
+          ],
+        },
+      },
+    ];
+
+    const result = renderTranslation(
+      'before <0>parent text and <0>nested content</0></0> after',
+      declarations,
+    );
+
+    expect(result).toHaveLength(3);
+
+    expect(result[0]).toBe('before ');
+
+    expect(result[2]).toBe(' after');
+
+    const parent = result[1];
+
+    expect(parent.type).toBe('div');
+
+    expect(parent.props.style).toEqual({ color: 'red' });
+
+    const parentChildren = React.Children.toArray(parent.props.children);
+
+    expect(parentChildren).toHaveLength(2);
+
+    expect(parentChildren[0]).toBe('parent text and ');
+
+    const nested = parentChildren[1];
+
+    expect(React.isValidElement(nested)).toBe(true);
+
+    expect(nested.type).toBe('code');
+
+    expect(nested.props.children).toBe('nested content');
+  });
+
+  it('should handle complex translations with multiple interpolation types and nested structures', () => {
+    const declarations = [
+      { type: 'strong' },
+      { type: 'strong' },
+      {
+        type: 'div',
+        props: {
+          style: { color: 'red' },
+          children: [{ type: 'code' }],
+        },
+      },
+    ];
+
+    const translation =
+      '<0>exciting!</0> hi there <1>friend</1>  and  another nested <2>with regular text and a date: <0>10/11/2025</0></2>';
+
+    const result = renderTranslation(translation, declarations);
+
+    expect(result).toHaveLength(5);
+
+    const exciting = result[0];
+
+    expect(React.isValidElement(exciting)).toBe(true);
+
+    expect(exciting.type).toBe('strong');
+
+    expect(exciting.props.children).toBe('exciting!');
+
+    expect(result[1]).toBe(' hi there ');
+
+    const friend = result[2];
+
+    expect(React.isValidElement(friend)).toBe(true);
+
+    expect(friend.type).toBe('strong');
+
+    expect(friend.props.children).toBe('friend');
+
+    expect(result[3]).toBe('  and  another nested ');
+
+    const boxElement = result[4];
+
+    expect(React.isValidElement(boxElement)).toBe(true);
+
+    expect(boxElement.type).toBe('div');
+
+    expect(boxElement.props.style).toEqual({ color: 'red' });
+
+    const boxChildren = React.Children.toArray(boxElement.props.children);
+
+    expect(boxChildren).toHaveLength(2);
+
+    expect(boxChildren[0]).toBe('with regular text and a date: ');
+
+    const codeElement = boxChildren[1];
+
+    expect(React.isValidElement(codeElement)).toBe(true);
+
+    expect(codeElement.type).toBe('code');
+
+    expect(codeElement.props.children).toBe('10/11/2025');
+  });
+
+  it('should handle list elements with nested list item children', () => {
+    const declarations = [
+      {
+        type: 'ul',
+        props: {
+          children: [{ type: 'li' }, { type: 'li' }],
+        },
+      },
+    ];
+
+    const translation = 'and the fallback <0><0>one</0><1>two</1></0>';
+
+    const result = renderTranslation(translation, declarations);
+
+    expect(result).toHaveLength(2);
+
+    expect(result[0]).toBe('and the fallback ');
+
+    const ul = result[1];
+
+    expect(React.isValidElement(ul)).toBe(true);
+
+    expect(ul.type).toBe('ul');
+
+    const ulChildren = React.Children.toArray(ul.props.children);
+
+    expect(ulChildren).toHaveLength(2);
+
+    const li1 = ulChildren[0];
+
+    expect(React.isValidElement(li1)).toBe(true);
+
+    expect(li1.type).toBe('li');
+
+    expect(li1.props.children).toBe('one');
+
+    const li2 = ulChildren[1];
+
+    expect(React.isValidElement(li2)).toBe(true);
+
+    expect(li2.type).toBe('li');
+
+    expect(li2.props.children).toBe('two');
+  });
+
+  it('should handle deeply nested tags interspersed with sibling text content', () => {
+    const declarations = [
+      { type: 'strong' },
+      { type: 'em' },
+      {
+        type: 'div',
+        props: {
+          children: [{ type: 'span' }],
+        },
+      },
+    ];
+
+    const translation =
+      'Start <0>bold</0> middle <1>italic</1> then <2>container <0>nested span</0></2> end';
+
+    const result = renderTranslation(translation, declarations);
+
+    expect(result).toHaveLength(7);
+
+    expect(result[0]).toBe('Start ');
+
+    const bold = result[1];
+
+    expect(bold.type).toBe('strong');
+
+    expect(bold.props.children).toBe('bold');
+
+    expect(result[2]).toBe(' middle ');
+
+    const italic = result[3];
+
+    expect(italic.type).toBe('em');
+
+    expect(italic.props.children).toBe('italic');
+
+    expect(result[4]).toBe(' then ');
+
+    const div = result[5];
+
+    expect(div.type).toBe('div');
+
+    const divChildren = React.Children.toArray(div.props.children);
+
+    expect(divChildren).toHaveLength(2);
+
+    expect(divChildren[0]).toBe('container ');
+
+    const span = divChildren[1];
+
+    expect(span.type).toBe('span');
+
+    expect(span.props.children).toBe('nested span');
+
+    expect(result[6]).toBe(' end');
+  });
+
+  it('should treat literal HTML tags as text, not component placeholders', () => {
+    // This tests the case where ICU messageformat might return literal HTML tags
+    // These should be rendered as text, not interpreted as component placeholders
+    const result = renderTranslation('and the fallback <ul><li>one</li><li>two</li></ul>', []);
+
+    expect(result).toEqual(['and the fallback <ul><li>one</li><li>two</li></ul>']);
+  });
+
+  it('should treat numbered tags as literal text when no corresponding declaration exists', () => {
+    // This tests the edge case where a translation has numbered tags but no declarations
+    // This can happen when using ICU select/plural with literal HTML in some branches
+    // The system should gracefully render these as literal text instead of throwing
+    const result = renderTranslation('and the fallback <3><0>one</0><1>two</1></3>', []);
+
+    // Each tag and text segment is returned as a separate array element
+    expect(result).toEqual([
+      'and the fallback ',
+      '<3>',
+      '<0>',
+      'one',
+      '</0>',
+      '<1>',
+      'two',
+      '</1>',
+      '</3>',
+    ]);
+  });
+
+  it('should handle literal tags nested inside valid components', () => {
+    // This tests the case where a literal tag (missing declaration) appears inside a valid component
+    // This covers the stack.length > 0 branch for literal tag handling
+    const declarations = [{ type: 'div', props: {} }];
+
+    const result = renderTranslation('<0>Text <1>missing</1> more</0>', declarations);
+
+    expect(result).toHaveLength(1);
+
+    const div = result[0];
+
+    expect(React.isValidElement(div)).toBe(true);
+
+    expect(div.type).toBe('div');
+
+    const divChildren = React.Children.toArray(div.props.children);
+
+    // Should have: 'Text ', '<1>', 'missing', '</1>', ' more'
+    expect(divChildren).toHaveLength(5);
+
+    expect(divChildren[0]).toBe('Text ');
+
+    expect(divChildren[1]).toBe('<1>');
+
+    expect(divChildren[2]).toBe('missing');
+
+    expect(divChildren[3]).toBe('</1>');
+
+    expect(divChildren[4]).toBe(' more');
+  });
+
+  it('should handle multiple nested literal tags inside valid components', () => {
+    // Test multiple literal tags at different nesting levels
+    const declarations = [
+      { type: 'div', props: {} },
+      { type: 'span', props: {} },
+    ];
+
+    const result = renderTranslation('<0><1>Valid <2>literal</2></1> text</0>', declarations);
+
+    expect(result).toHaveLength(1);
+
+    const div = result[0];
+
+    expect(div.type).toBe('div');
+
+    const divChildren = React.Children.toArray(div.props.children);
+
+    // Should have a span element and ' text'
+    expect(divChildren).toHaveLength(2);
+
+    const span = divChildren[0];
+
+    expect(React.isValidElement(span)).toBe(true);
+
+    expect(span.type).toBe('span');
+
+    const spanChildren = React.Children.toArray(span.props.children);
+
+    // Should have: 'Valid ', '<2>', 'literal', '</2>'
+    expect(spanChildren).toHaveLength(4);
+
+    expect(spanChildren[0]).toBe('Valid ');
+
+    expect(spanChildren[1]).toBe('<2>');
+
+    expect(spanChildren[2]).toBe('literal');
+
+    expect(spanChildren[3]).toBe('</2>');
+
+    expect(divChildren[1]).toBe(' text');
+  });
+});

--- a/test/IcuTrans/utils/tokenizer.spec.js
+++ b/test/IcuTrans/utils/tokenizer.spec.js
@@ -1,0 +1,918 @@
+import { describe, it, expect } from 'vitest';
+import { tokenize } from '../../../src/IcuTransUtils';
+
+describe('tokenizer', () => {
+  describe('plain text', () => {
+    it('should tokenize plain text without any tags', () => {
+      const result = tokenize('Hello world');
+
+      expect(result).toEqual([
+        {
+          type: 'Text',
+          value: 'Hello world',
+          position: 0,
+        },
+      ]);
+    });
+
+    it('should handle empty strings', () => {
+      const result = tokenize('');
+
+      expect(result).toEqual([]);
+    });
+
+    it('should preserve whitespace-only text', () => {
+      const result = tokenize('   ');
+
+      expect(result).toEqual([
+        {
+          type: 'Text',
+          value: '   ',
+          position: 0,
+        },
+      ]);
+    });
+
+    it('should preserve newlines and tabs', () => {
+      const result = tokenize('Hello\nWorld\tTest');
+
+      expect(result).toEqual([
+        {
+          type: 'Text',
+          value: 'Hello\nWorld\tTest',
+          position: 0,
+        },
+      ]);
+    });
+  });
+
+  describe('single tag', () => {
+    it('should tokenize a simple opening and closing tag', () => {
+      const result = tokenize('<0>text</0>');
+
+      expect(result).toEqual([
+        {
+          type: 'TagOpen',
+          value: '<0>',
+          position: 0,
+          tagNumber: 0,
+        },
+        {
+          type: 'Text',
+          value: 'text',
+          position: 3,
+        },
+        {
+          type: 'TagClose',
+          value: '</0>',
+          position: 7,
+          tagNumber: 0,
+        },
+      ]);
+    });
+
+    it('should tokenize tag with single-digit numbers', () => {
+      const result = tokenize('<5>content</5>');
+
+      expect(result).toEqual([
+        {
+          type: 'TagOpen',
+          value: '<5>',
+          position: 0,
+          tagNumber: 5,
+        },
+        {
+          type: 'Text',
+          value: 'content',
+          position: 3,
+        },
+        {
+          type: 'TagClose',
+          value: '</5>',
+          position: 10,
+          tagNumber: 5,
+        },
+      ]);
+    });
+
+    it('should tokenize tag with multi-digit numbers', () => {
+      const result = tokenize('<123>test</123>');
+
+      expect(result).toEqual([
+        {
+          type: 'TagOpen',
+          value: '<123>',
+          position: 0,
+          tagNumber: 123,
+        },
+        {
+          type: 'Text',
+          value: 'test',
+          position: 5,
+        },
+        {
+          type: 'TagClose',
+          value: '</123>',
+          position: 9,
+          tagNumber: 123,
+        },
+      ]);
+    });
+
+    it('should handle empty tags', () => {
+      const result = tokenize('<0></0>');
+
+      expect(result).toEqual([
+        {
+          type: 'TagOpen',
+          value: '<0>',
+          position: 0,
+          tagNumber: 0,
+        },
+        {
+          type: 'TagClose',
+          value: '</0>',
+          position: 3,
+          tagNumber: 0,
+        },
+      ]);
+    });
+  });
+
+  describe('text with tags', () => {
+    it('should tokenize text before a tag', () => {
+      const result = tokenize('Hello <0>world</0>');
+
+      expect(result).toEqual([
+        {
+          type: 'Text',
+          value: 'Hello ',
+          position: 0,
+        },
+        {
+          type: 'TagOpen',
+          value: '<0>',
+          position: 6,
+          tagNumber: 0,
+        },
+        {
+          type: 'Text',
+          value: 'world',
+          position: 9,
+        },
+        {
+          type: 'TagClose',
+          value: '</0>',
+          position: 14,
+          tagNumber: 0,
+        },
+      ]);
+    });
+
+    it('should tokenize text after a tag', () => {
+      const result = tokenize('<0>Hello</0> world');
+
+      expect(result).toEqual([
+        {
+          type: 'TagOpen',
+          value: '<0>',
+          position: 0,
+          tagNumber: 0,
+        },
+        {
+          type: 'Text',
+          value: 'Hello',
+          position: 3,
+        },
+        {
+          type: 'TagClose',
+          value: '</0>',
+          position: 8,
+          tagNumber: 0,
+        },
+        {
+          type: 'Text',
+          value: ' world',
+          position: 12,
+        },
+      ]);
+    });
+
+    it('should tokenize text before, inside, and after tags', () => {
+      const result = tokenize('Start <0>middle</0> end');
+
+      expect(result).toEqual([
+        {
+          type: 'Text',
+          value: 'Start ',
+          position: 0,
+        },
+        {
+          type: 'TagOpen',
+          value: '<0>',
+          position: 6,
+          tagNumber: 0,
+        },
+        {
+          type: 'Text',
+          value: 'middle',
+          position: 9,
+        },
+        {
+          type: 'TagClose',
+          value: '</0>',
+          position: 15,
+          tagNumber: 0,
+        },
+        {
+          type: 'Text',
+          value: ' end',
+          position: 19,
+        },
+      ]);
+    });
+  });
+
+  describe('multiple tags', () => {
+    it('should tokenize multiple consecutive tags', () => {
+      const result = tokenize('<0>first</0><1>second</1>');
+
+      expect(result).toEqual([
+        {
+          type: 'TagOpen',
+          value: '<0>',
+          position: 0,
+          tagNumber: 0,
+        },
+        {
+          type: 'Text',
+          value: 'first',
+          position: 3,
+        },
+        {
+          type: 'TagClose',
+          value: '</0>',
+          position: 8,
+          tagNumber: 0,
+        },
+        {
+          type: 'TagOpen',
+          value: '<1>',
+          position: 12,
+          tagNumber: 1,
+        },
+        {
+          type: 'Text',
+          value: 'second',
+          position: 15,
+        },
+        {
+          type: 'TagClose',
+          value: '</1>',
+          position: 21,
+          tagNumber: 1,
+        },
+      ]);
+    });
+
+    it('should tokenize multiple tags with text between them', () => {
+      const result = tokenize('<0>bold</0> and <1>italic</1>');
+
+      expect(result).toEqual([
+        {
+          type: 'TagOpen',
+          value: '<0>',
+          position: 0,
+          tagNumber: 0,
+        },
+        {
+          type: 'Text',
+          value: 'bold',
+          position: 3,
+        },
+        {
+          type: 'TagClose',
+          value: '</0>',
+          position: 7,
+          tagNumber: 0,
+        },
+        {
+          type: 'Text',
+          value: ' and ',
+          position: 11,
+        },
+        {
+          type: 'TagOpen',
+          value: '<1>',
+          position: 16,
+          tagNumber: 1,
+        },
+        {
+          type: 'Text',
+          value: 'italic',
+          position: 19,
+        },
+        {
+          type: 'TagClose',
+          value: '</1>',
+          position: 25,
+          tagNumber: 1,
+        },
+      ]);
+    });
+
+    it('should handle the same tag number used multiple times', () => {
+      const result = tokenize('<0>first</0> and <0>second</0>');
+
+      expect(result).toEqual([
+        {
+          type: 'TagOpen',
+          value: '<0>',
+          position: 0,
+          tagNumber: 0,
+        },
+        {
+          type: 'Text',
+          value: 'first',
+          position: 3,
+        },
+        {
+          type: 'TagClose',
+          value: '</0>',
+          position: 8,
+          tagNumber: 0,
+        },
+        {
+          type: 'Text',
+          value: ' and ',
+          position: 12,
+        },
+        {
+          type: 'TagOpen',
+          value: '<0>',
+          position: 17,
+          tagNumber: 0,
+        },
+        {
+          type: 'Text',
+          value: 'second',
+          position: 20,
+        },
+        {
+          type: 'TagClose',
+          value: '</0>',
+          position: 26,
+          tagNumber: 0,
+        },
+      ]);
+    });
+  });
+
+  describe('nested tags', () => {
+    it('should tokenize nested tags', () => {
+      const result = tokenize('<0>outer <1>inner</1> text</0>');
+
+      expect(result).toEqual([
+        {
+          type: 'TagOpen',
+          value: '<0>',
+          position: 0,
+          tagNumber: 0,
+        },
+        {
+          type: 'Text',
+          value: 'outer ',
+          position: 3,
+        },
+        {
+          type: 'TagOpen',
+          value: '<1>',
+          position: 9,
+          tagNumber: 1,
+        },
+        {
+          type: 'Text',
+          value: 'inner',
+          position: 12,
+        },
+        {
+          type: 'TagClose',
+          value: '</1>',
+          position: 17,
+          tagNumber: 1,
+        },
+        {
+          type: 'Text',
+          value: ' text',
+          position: 21,
+        },
+        {
+          type: 'TagClose',
+          value: '</0>',
+          position: 26,
+          tagNumber: 0,
+        },
+      ]);
+    });
+
+    it('should tokenize deeply nested tags', () => {
+      const result = tokenize('<0><1><2>deep</2></1></0>');
+
+      expect(result).toEqual([
+        {
+          type: 'TagOpen',
+          value: '<0>',
+          position: 0,
+          tagNumber: 0,
+        },
+        {
+          type: 'TagOpen',
+          value: '<1>',
+          position: 3,
+          tagNumber: 1,
+        },
+        {
+          type: 'TagOpen',
+          value: '<2>',
+          position: 6,
+          tagNumber: 2,
+        },
+        {
+          type: 'Text',
+          value: 'deep',
+          position: 9,
+        },
+        {
+          type: 'TagClose',
+          value: '</2>',
+          position: 13,
+          tagNumber: 2,
+        },
+        {
+          type: 'TagClose',
+          value: '</1>',
+          position: 17,
+          tagNumber: 1,
+        },
+        {
+          type: 'TagClose',
+          value: '</0>',
+          position: 21,
+          tagNumber: 0,
+        },
+      ]);
+    });
+  });
+
+  describe('non-tag angle brackets', () => {
+    it('should treat < as text when not followed by digits', () => {
+      const result = tokenize('5 < 10');
+
+      expect(result).toEqual([
+        {
+          type: 'Text',
+          value: '5 < 10',
+          position: 0,
+        },
+      ]);
+    });
+
+    it('should treat </ as text when not followed by digits and >', () => {
+      const result = tokenize('a </div>');
+
+      expect(result).toEqual([
+        {
+          type: 'Text',
+          value: 'a </div>',
+          position: 0,
+        },
+      ]);
+    });
+
+    it('should treat incomplete tags as text', () => {
+      const result = tokenize('<0 not a tag');
+
+      expect(result).toEqual([
+        {
+          type: 'Text',
+          value: '<0 not a tag',
+          position: 0,
+        },
+      ]);
+    });
+
+    it("should handle text with < and > that aren't tags", () => {
+      const result = tokenize('x < y && z > w');
+
+      expect(result).toEqual([
+        {
+          type: 'Text',
+          value: 'x < y && z > w',
+          position: 0,
+        },
+      ]);
+    });
+
+    it('should handle mixed valid tags and non-tag brackets', () => {
+      const result = tokenize('<0>5 < 10</0>');
+
+      expect(result).toEqual([
+        {
+          type: 'TagOpen',
+          value: '<0>',
+          position: 0,
+          tagNumber: 0,
+        },
+        {
+          type: 'Text',
+          value: '5 < 10',
+          position: 3,
+        },
+        {
+          type: 'TagClose',
+          value: '</0>',
+          position: 9,
+          tagNumber: 0,
+        },
+      ]);
+    });
+  });
+
+  describe('ICU variable placeholders', () => {
+    it('should treat ICU variables as text', () => {
+      const result = tokenize('{userName}');
+
+      expect(result).toEqual([
+        {
+          type: 'Text',
+          value: '{userName}',
+          position: 0,
+        },
+      ]);
+    });
+
+    it('should handle tags with ICU variables', () => {
+      const result = tokenize('<0>Hello {userName}</0>');
+
+      expect(result).toEqual([
+        {
+          type: 'TagOpen',
+          value: '<0>',
+          position: 0,
+          tagNumber: 0,
+        },
+        {
+          type: 'Text',
+          value: 'Hello {userName}',
+          position: 3,
+        },
+        {
+          type: 'TagClose',
+          value: '</0>',
+          position: 19,
+          tagNumber: 0,
+        },
+      ]);
+    });
+
+    it('should handle complex ICU plurals', () => {
+      const result = tokenize('<0>{count, plural, one {# item} other {# items}}</0>');
+
+      expect(result).toEqual([
+        {
+          type: 'TagOpen',
+          value: '<0>',
+          position: 0,
+          tagNumber: 0,
+        },
+        {
+          type: 'Text',
+          value: '{count, plural, one {# item} other {# items}}',
+          position: 3,
+        },
+        {
+          type: 'TagClose',
+          value: '</0>',
+          position: 48,
+          tagNumber: 0,
+        },
+      ]);
+    });
+  });
+
+  describe('position tracking', () => {
+    it('should track positions correctly for single tag', () => {
+      const result = tokenize('<0>test</0>');
+
+      expect(result[0].position).toBe(0); // <0>
+
+      expect(result[1].position).toBe(3); // test
+
+      expect(result[2].position).toBe(7); // </0>
+    });
+
+    it('should track positions correctly with leading text', () => {
+      const result = tokenize('Hello <0>world</0>');
+
+      expect(result[0].position).toBe(0); // Hello
+
+      expect(result[1].position).toBe(6); // <0>
+
+      expect(result[2].position).toBe(9); // world
+
+      expect(result[3].position).toBe(14); // </0>
+    });
+
+    it('should track positions correctly for nested tags', () => {
+      const result = tokenize('<0>a <1>b</1> c</0>');
+
+      expect(result[0].position).toBe(0); // <0>
+
+      expect(result[1].position).toBe(3); // a
+
+      expect(result[2].position).toBe(5); // <1>
+
+      expect(result[3].position).toBe(8); // b
+
+      expect(result[4].position).toBe(9); // </1>
+
+      expect(result[5].position).toBe(13); // c
+
+      expect(result[6].position).toBe(15); // </0>
+    });
+
+    it('should track positions correctly with multi-digit tag numbers', () => {
+      const result = tokenize('<123>test</123>');
+
+      expect(result[0].position).toBe(0); // <123>
+
+      expect(result[1].position).toBe(5); // test
+
+      expect(result[2].position).toBe(9); // </123>
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle tag at the very end of string', () => {
+      const result = tokenize('text <0>end</0>');
+
+      expect(result).toHaveLength(4);
+
+      expect(result[3].type).toBe('TagClose');
+    });
+
+    it('should handle tag at the very beginning of string', () => {
+      const result = tokenize('<0>start</0> text');
+
+      expect(result).toHaveLength(4);
+
+      expect(result[0].type).toBe('TagOpen');
+    });
+
+    it('should handle only opening tags (no validation)', () => {
+      // Note: tokenizer doesn't validate matching, just tokenizes
+      const result = tokenize('<0>text');
+
+      expect(result).toEqual([
+        {
+          type: 'TagOpen',
+          value: '<0>',
+          position: 0,
+          tagNumber: 0,
+        },
+        {
+          type: 'Text',
+          value: 'text',
+          position: 3,
+        },
+      ]);
+    });
+
+    it('should handle only closing tags (no validation)', () => {
+      // Note: tokenizer doesn't validate matching, just tokenizes
+      const result = tokenize('text</0>');
+
+      expect(result).toEqual([
+        {
+          type: 'Text',
+          value: 'text',
+          position: 0,
+        },
+        {
+          type: 'TagClose',
+          value: '</0>',
+          position: 4,
+          tagNumber: 0,
+        },
+      ]);
+    });
+
+    it('should handle mismatched tag numbers (no validation)', () => {
+      // Note: tokenizer doesn't validate matching, just tokenizes
+      const result = tokenize('<0>text</1>');
+
+      expect(result).toEqual([
+        {
+          type: 'TagOpen',
+          value: '<0>',
+          position: 0,
+          tagNumber: 0,
+        },
+        {
+          type: 'Text',
+          value: 'text',
+          position: 3,
+        },
+        {
+          type: 'TagClose',
+          value: '</1>',
+          position: 7,
+          tagNumber: 1,
+        },
+      ]);
+    });
+
+    it('should handle special characters inside tags', () => {
+      const result = tokenize('<0>Hello & goodbye \'quotes\' "double"</0>');
+
+      expect(result).toEqual([
+        {
+          type: 'TagOpen',
+          value: '<0>',
+          position: 0,
+          tagNumber: 0,
+        },
+        {
+          type: 'Text',
+          value: 'Hello & goodbye \'quotes\' "double"',
+          position: 3,
+        },
+        {
+          type: 'TagClose',
+          value: '</0>',
+          position: 36,
+          tagNumber: 0,
+        },
+      ]);
+    });
+
+    it('should handle Unicode characters', () => {
+      const result = tokenize('<0>Hello 世界 🌍</0>');
+
+      expect(result).toEqual([
+        {
+          type: 'TagOpen',
+          value: '<0>',
+          position: 0,
+          tagNumber: 0,
+        },
+        {
+          type: 'Text',
+          value: 'Hello 世界 🌍',
+          position: 3,
+        },
+        {
+          type: 'TagClose',
+          value: '</0>',
+          position: 14, // Emoji counts as 2 characters in JavaScript
+          tagNumber: 0,
+        },
+      ]);
+    });
+  });
+
+  describe('real-world examples', () => {
+    it('should tokenize a link with an icon', () => {
+      const result = tokenize('See <0>documentation <1></1></0> for details.');
+
+      expect(result).toHaveLength(7);
+
+      expect(result[0].type).toBe('Text');
+
+      expect(result[0].value).toBe('See ');
+
+      expect(result[1].type).toBe('TagOpen');
+
+      expect(result[1].tagNumber).toBe(0);
+
+      expect(result[2].type).toBe('Text');
+
+      expect(result[2].value).toBe('documentation ');
+
+      expect(result[3].type).toBe('TagOpen');
+
+      expect(result[3].tagNumber).toBe(1);
+
+      expect(result[4].type).toBe('TagClose');
+
+      expect(result[4].tagNumber).toBe(1);
+
+      expect(result[5].type).toBe('TagClose');
+
+      expect(result[5].tagNumber).toBe(0);
+
+      expect(result[6].type).toBe('Text');
+
+      expect(result[6].value).toBe(' for details.');
+    });
+
+    it('should tokenize a complex sentence with multiple styled parts', () => {
+      const result = tokenize(
+        'Click <0>here</0> to view your <1>account settings</1> or <2>log out</2>.',
+      );
+
+      const tagOpenTokens = result.filter((t) => t.type === 'TagOpen');
+      const tagCloseTokens = result.filter((t) => t.type === 'TagClose');
+      const textTokens = result.filter((t) => t.type === 'Text');
+
+      expect(tagOpenTokens).toHaveLength(3);
+
+      expect(tagCloseTokens).toHaveLength(3);
+
+      expect(textTokens).toHaveLength(7); // Text between and inside tags
+
+      // Verify tag numbers are correct
+      expect(tagOpenTokens[0].tagNumber).toBe(0);
+
+      expect(tagOpenTokens[1].tagNumber).toBe(1);
+
+      expect(tagOpenTokens[2].tagNumber).toBe(2);
+    });
+
+    it('should tokenize nested list structure', () => {
+      const result = tokenize('<0><0>First item</0><1>Second item</1></0>');
+
+      expect(result[0]).toMatchObject({
+        type: 'TagOpen',
+        tagNumber: 0,
+      });
+
+      expect(result[1]).toMatchObject({
+        type: 'TagOpen',
+        tagNumber: 0,
+      });
+
+      expect(result[2]).toMatchObject({
+        type: 'Text',
+        value: 'First item',
+      });
+
+      expect(result[3]).toMatchObject({
+        type: 'TagClose',
+        tagNumber: 0,
+      });
+
+      expect(result[4]).toMatchObject({
+        type: 'TagOpen',
+        tagNumber: 1,
+      });
+
+      expect(result[5]).toMatchObject({
+        type: 'Text',
+        value: 'Second item',
+      });
+
+      expect(result[6]).toMatchObject({
+        type: 'TagClose',
+        tagNumber: 1,
+      });
+
+      expect(result[7]).toMatchObject({
+        type: 'TagClose',
+        tagNumber: 0,
+      });
+    });
+  });
+
+  describe('type safety', () => {
+    it('should return tokens with correct types', () => {
+      const result = tokenize('<0>test</0>');
+
+      expect(result[0].type).toBe('TagOpen');
+
+      expect(result[1].type).toBe('Text');
+
+      expect(result[2].type).toBe('TagClose');
+    });
+
+    it('should include tagNumber only for tag tokens', () => {
+      const result = tokenize('<0>test</0>');
+
+      expect(result[0].tagNumber).toBeDefined();
+
+      expect(result[1].tagNumber).toBeUndefined();
+
+      expect(result[2].tagNumber).toBeDefined();
+    });
+
+    it('should always include position for all tokens', () => {
+      const result = tokenize('<0>test</0>');
+
+      result.forEach((token) => {
+        expect(token.position).toBeDefined();
+
+        expect(typeof token.position).toBe('number');
+      });
+    });
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -10,7 +10,7 @@ export default defineConfig({
 
     coverage: {
       reporter: ['text', 'html', 'json', 'lcov'],
-      include: ['**/src/*.{js,jsx}', '*.macro.js'],
+      include: ['**/src/**/*.{js,jsx}', '*.macro.js'],
       exclude: [
         '**/src/index.js',
         '**/src/shallowEqual.js',


### PR DESCRIPTION
Issue #1869

This adds a new `Trans` component that does not use `React.Children` under the hood, but instead uses `React.createElement` and expects a tree of components (`contents`) that instead passes in the components to render. This eliminates a whole slew of weird hard-to-diagnose bugs, and most importantly, makes `Trans` compatible with the new React compiler that was just released as version 1.0 last week.

A follow-up PR will adjust the icu macro to use this new component under the hood. It's designed to be a drop-in replacement for the code that is compiled, but requires a different parsing logic in the babel macro.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)