### PR TITLE
fix: ensure invalid identifiers are quoted in the props object

### DIFF
--- a/icu.macro.js
+++ b/icu.macro.js
@@ -364,7 +364,12 @@ function jsxElementToDeclaration(jsxElement, t) {
         propValue = t.nullLiteral();
       }
 
-      propsProperties.push(t.objectProperty(t.identifier(propName), propValue));
+      // Use string literal for keys that aren't valid identifiers (e.g., contain hyphens)
+      const propKey = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(propName)
+        ? t.identifier(propName)
+        : t.stringLiteral(propName);
+
+      propsProperties.push(t.objectProperty(propKey, propValue));
     }
   });
 

--- a/test/__snapshots__/icu.macro.spec.js.snap
+++ b/test/__snapshots__/icu.macro.spec.js.snap
@@ -1061,3 +1061,59 @@ const x = (
 );
 "
 `;
+
+exports[`macros > 23. macros > 23. macros 1`] = `
+"
+
+import { Trans } from "../../../icu.macro";
+
+const x = <Trans data-cy="test">Welcome, { name }!</Trans>
+    
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { IcuTrans } from 'react-i18next';
+const x = (
+  <IcuTrans
+    data-cy="test"
+    defaultTranslation="Welcome, {name}!"
+    content={[]}
+    values={{
+      name,
+    }}
+  />
+);
+"
+`;
+
+exports[`macros > 24. macros > 24. macros 1`] = `
+"
+
+import { Trans } from "../../../icu.macro";
+
+const x = <Trans data-cy="test" data-testid="trans-component">Welcome, <strong data-cy="name">{ name }</strong>!</Trans>
+    
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { IcuTrans } from 'react-i18next';
+const x = (
+  <IcuTrans
+    data-cy="test"
+    data-testid="trans-component"
+    defaultTranslation="Welcome, <0>{name}</0>!"
+    content={[
+      {
+        type: 'strong',
+        props: {
+          'data-cy': 'name',
+        },
+      },
+    ]}
+    values={{
+      name,
+    }}
+  />
+);
+"
+`;

--- a/test/icu.macro.spec.js
+++ b/test/icu.macro.spec.js
@@ -320,6 +320,16 @@ pluginTester({
 
       const x = <Trans>Welcome, &quot;{ name }&quot;!</Trans>
     `,
+    `
+      import { Trans } from "../../../icu.macro";
+
+      const x = <Trans data-cy="test">Welcome, { name }!</Trans>
+    `,
+    `
+      import { Trans } from "../../../icu.macro";
+
+      const x = <Trans data-cy="test" data-testid="trans-component">Welcome, <strong data-cy="name">{ name }</strong>!</Trans>
+    `,
     {
       code: `
         import React from "react"


### PR DESCRIPTION
Discovered in the wild: we need to use `'quoted-strings'` for props in contents that are not valid identifiers in javascript.

This fixes that (reference #1869)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)