### PR TITLE
fix: detect pre-transformation use of interpolation like number/date/etc.

### DIFF
--- a/icu.macro.js
+++ b/icu.macro.js
@@ -86,9 +86,12 @@ function ICUMacro({ references, state, babel }) {
           const elementName = openingElement.name;
           const isMemberExpression = babel.types.isJSXMemberExpression(elementName);
 
-          if (!isMemberExpression && elementName.name === 'IcuTrans') {
+          if (
+            !isMemberExpression &&
+            (elementName.name === 'IcuTrans' || elementName.name === 'Trans')
+          ) {
             // this is a valid use of number/date/time/etc.
-            // Only check IcuTrans since Trans transformation (lines 57-71) happens before this validation
+            // Check for both IcuTrans (after transformation) and Trans (during transformation)
             return;
           }
         }

--- a/test/__snapshots__/icu.macro.spec.js.snap
+++ b/test/__snapshots__/icu.macro.spec.js.snap
@@ -1117,3 +1117,90 @@ const x = (
 );
 "
 `;
+
+exports[`macros > 25. macros > 25. macros 1`] = `
+"
+
+import type { PackageDetail } from "@api/package";
+import type { ReactElement } from "react";
+import React from "react";
+
+import { number } from "../../../icu.macro";
+import { Trans } from "../../../icu.macro";
+import ProgressBar from "/ProgressBar";
+
+const UsageTracker = ({
+  packageDetail,
+  className,
+}: {
+  packageDetail: PackageDetail;
+  className?: string;
+}): ReactElement => {
+  const { k } = useI18nNamespace("usage");
+  const incomingRequestCount = packageDetail.incoming_requests;
+  const maxIncomingRequestsAllowed = packageDetail.incoming_requests_limit;
+  const prompt = (
+    <Trans i18nKey="usage-progress-bar-prompt">
+      <b>{number\`\${ incomingRequestCount }\`}</b> of {number\`\${ maxIncomingRequestsAllowed }\`} incoming requests since
+      the first day of the month
+    </Trans>
+  );
+  return (
+    <div className={className} data-cy="usage-tracker">
+      <ProgressBar
+        currentCount={incomingRequestCount}
+        limitCount={maxIncomingRequestsAllowed}
+        prompt={prompt}
+      />
+    </div>
+  );
+};
+
+export default UsageTracker;
+    
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { IcuTrans, number } from 'react-i18next';
+import type { PackageDetail } from '@api/package';
+import type { ReactElement } from 'react';
+import React from 'react';
+import ProgressBar from '/ProgressBar';
+const UsageTracker = ({
+  packageDetail,
+  className,
+}: {
+  packageDetail: PackageDetail,
+  className?: string,
+}): ReactElement => {
+  const { k } = useI18nNamespace('usage');
+  const incomingRequestCount = packageDetail.incoming_requests;
+  const maxIncomingRequestsAllowed = packageDetail.incoming_requests_limit;
+  const prompt = (
+    <IcuTrans
+      i18nKey="usage-progress-bar-prompt"
+      defaultTranslation="<0>{incomingRequestCount, number}</0> of {maxIncomingRequestsAllowed, number} incoming requests since\\n      the first day of the month"
+      content={[
+        {
+          type: 'b',
+        },
+      ]}
+      values={{
+        incomingRequestCount,
+        maxIncomingRequestsAllowed,
+      }}
+    />
+  );
+  return (
+    <div className={className} data-cy="usage-tracker">
+      <ProgressBar
+        currentCount={incomingRequestCount}
+        limitCount={maxIncomingRequestsAllowed}
+        prompt={prompt}
+      />
+    </div>
+  );
+};
+export default UsageTracker;
+"
+`;

--- a/test/icu.macro.spec.js
+++ b/test/icu.macro.spec.js
@@ -18,7 +18,7 @@ globalThis.expect = expect;
 pluginTester({
   plugin,
   snapshot: true,
-  babelOptions: { filename: __filename, parserOpts: { plugins: ['jsx'] } },
+  babelOptions: { filename: __filename, parserOpts: { plugins: ['jsx', 'typescript'] } },
   tests: [
     `
       import { Trans } from '../../../icu.macro'
@@ -329,6 +329,44 @@ pluginTester({
       import { Trans } from "../../../icu.macro";
 
       const x = <Trans data-cy="test" data-testid="trans-component">Welcome, <strong data-cy="name">{ name }</strong>!</Trans>
+    `,
+    `
+      import type { PackageDetail } from "@api/package";
+      import type { ReactElement } from "react";
+      import React from "react";
+
+      import { number } from "../../../icu.macro";
+      import { Trans } from "../../../icu.macro";
+      import ProgressBar from "/ProgressBar";
+
+      const UsageTracker = ({
+        packageDetail,
+        className,
+      }: {
+        packageDetail: PackageDetail;
+        className?: string;
+      }): ReactElement => {
+        const { k } = useI18nNamespace("usage");
+        const incomingRequestCount = packageDetail.incoming_requests;
+        const maxIncomingRequestsAllowed = packageDetail.incoming_requests_limit;
+        const prompt = (
+          <Trans i18nKey="usage-progress-bar-prompt">
+            <b>{number\`\${ incomingRequestCount }\`}</b> of {number\`\${ maxIncomingRequestsAllowed }\`} incoming requests since
+            the first day of the month
+          </Trans>
+        );
+        return (
+          <div className={className} data-cy="usage-tracker">
+            <ProgressBar
+              currentCount={incomingRequestCount}
+              limitCount={maxIncomingRequestsAllowed}
+              prompt={prompt}
+            />
+          </div>
+        );
+      };
+
+      export default UsageTracker;
     `,
     {
       code: `


### PR DESCRIPTION
References #1869

Discovered in the wild: pre-transformation sometimes didn't recognize `number` as being within `Trans`. This adds a test case and fixes the problem (did red-green TDD)

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)