### PR TITLE
fix: add i18n wrapper for React Compiler and React.memo compatibility

### DIFF
--- a/src/useTranslation.js
+++ b/src/useTranslation.js
@@ -129,12 +129,25 @@ export const useTranslation = (ns, props = {}) => {
   const finalI18n = i18n || {};
 
   const ret = useMemo(() => {
-    const arr = [t, finalI18n, ready];
+    const i18nWrapper = Object.create(
+      Object.getPrototypeOf(finalI18n),
+      Object.getOwnPropertyDescriptors(finalI18n),
+    );
+
+    // Store reference to the original instance for tests/debugging
+    Object.defineProperty(i18nWrapper, '__original', {
+      value: finalI18n,
+      writable: false,
+      enumerable: false,
+      configurable: false,
+    });
+
+    const arr = [t, i18nWrapper, ready];
     arr.t = t;
-    arr.i18n = finalI18n;
+    arr.i18n = i18nWrapper;
     arr.ready = ready;
     return arr;
-  }, [t, finalI18n, ready]);
+  }, [t, finalI18n, ready, finalI18n.resolvedLanguage, finalI18n.language, finalI18n.languages]);
 
   if (i18n && useSuspense && !ready) {
     throw new Promise((resolve) => {

--- a/test/I18nextProvider.spec.jsx
+++ b/test/I18nextProvider.spec.jsx
@@ -38,7 +38,8 @@ describe('I18nextProvider', () => {
       const { t, i18n } = useTranslation('translation');
 
       expect(typeof t).toBe('function');
-      expect(i18n).toBe(instance);
+      // expect(i18n).toBe(instance);
+      expect(i18n.__original).toBe(instance);
 
       return <div>{t('key1')}</div>;
     }

--- a/test/useTranslation.advanced.spec.js
+++ b/test/useTranslation.advanced.spec.js
@@ -67,7 +67,8 @@ describe('useTranslation mounting and re-render', () => {
     // 3. Hook should now be ready and functional
     expect(result.current.ready).toBe(true);
     expect(result.current.t('key')).toBe('translated_key');
-    expect(result.current.i18n).toBe(mockI18n);
+    // expect(result.current.i18n).toBe(mockI18n);
+    expect(result.current.i18n.__original).toBe(mockI18n);
   });
 
   /**

--- a/test/useTranslation.spec.jsx
+++ b/test/useTranslation.spec.jsx
@@ -21,7 +21,7 @@ describe('useTranslation', () => {
       const { t, i18n } = result.current;
       expect(t('key1')).toBe('test');
       expect(t(($) => $.key1)).toBe('test');
-      expect(i18nInstance).toBe(i18n);
+      expect(i18n.__original).toBe(i18nInstance);
     });
   });
 
@@ -48,7 +48,8 @@ describe('useTranslation', () => {
       const { result } = renderHook(() => useTranslation('translation', { i18n: i18nInstance }));
       const [t, i18n] = result.current;
       expect(t('key1')).toBe('test');
-      expect(i18n).toBe(i18nInstance);
+      // expect(i18n).toBe(i18nInstance);
+      expect(i18n.__original).toBe(i18nInstance);
     });
   });
 

--- a/test/withTranslation.keyPrefix.spec.jsx
+++ b/test/withTranslation.keyPrefix.spec.jsx
@@ -15,7 +15,8 @@ describe('withTranslation', () => {
     render() {
       const { t, i18n: instance } = this.props;
       expect(typeof t).toBe('function');
-      expect(instance).toBe(i18n);
+      // expect(instance).toBe(i18n);
+      expect(instance.__original).toBe(i18n);
 
       return <div>{t('deepKey1')}</div>;
     }

--- a/test/withTranslation.spec.jsx
+++ b/test/withTranslation.spec.jsx
@@ -15,7 +15,8 @@ describe('withTranslation', () => {
     render() {
       const { t, i18n: instance } = this.props;
       expect(typeof t).toBe('function');
-      expect(instance).toBe(i18n);
+      // expect(instance).toBe(i18n);
+      expect(instance.__original).toBe(i18n);
 
       return (
         <div>


### PR DESCRIPTION
https://github.com/i18next/react-i18next/issues/1863#issuecomment-3491246391

Creates a new object wrapper for the i18n instance that changes reference when language properties change. This ensures React Compiler and React.memo can properly detect changes and trigger re-renders.

The wrapper maintains full API compatibility by delegating to the original instance via prototype chain. A non-enumerable __original property is added for test verification.

Fixes compatibility issues with babel-plugin-react-compiler where accessing i18n.language inside callbacks was not triggering re-renders despite the component re-rendering.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

