### PR TITLE
docs: remove broken Code Climate GPA badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # react-i18next [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=Awesome%20react-i18next%20for%20react.js%20based%20on%20i18next%20internationalization%20ecosystem%20&url=https://github.com/i18next/react-i18next&via=jamuhl&hashtags=i18n,reactjs,js,dev)
 
 [![CI](https://github.com/i18next/react-i18next/actions/workflows/CI.yml/badge.svg)](https://github.com/i18next/react-i18next/actions/workflows/CI.yml)
-[![Code Climate](https://codeclimate.com/github/codeclimate/codeclimate/badges/gpa.svg)](https://codeclimate.com/github/i18next/react-i18next)
 [![Coverage Status](https://coveralls.io/repos/github/i18next/react-i18next/badge.svg)](https://coveralls.io/github/i18next/react-i18next)
 [![Quality][quality-badge]][quality-url]
 [![npm][npm-dl-badge]][npm-url]


### PR DESCRIPTION
This PR removes the Code Climate GPA badge from the README. The badge currently displays a "no longer available" error because Code Climate has deprecated the GPA metric in favor of Maintainability grades, and the legacy link for this project is no longer functional. Removing it improves the documentation quality by eliminating dead assets.

<img width="726" height="296" alt="image" src="https://github.com/user-attachments/assets/75418f72-d1ab-4264-a063-8adfa717a5e1" />


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)