### PR TITLE
fix #1899

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -47,7 +47,7 @@ export interface IcuTransContentDeclaration {
  * Props for IcuTransWithoutContext component (no React context)
  */
 export type IcuTransWithoutContextProps<
-  Key extends ParseKeys<Ns, TOpt, KPrefix> = string,
+  Key extends ParseKeys<Ns, TOpt, KPrefix>,
   Ns extends Namespace = _DefaultNamespace,
   KPrefix = undefined,
   TContext extends string | undefined = undefined,
@@ -73,7 +73,7 @@ export type IcuTransWithoutContextProps<
  * Props for IcuTrans component (with React context support)
  */
 export type IcuTransProps<
-  Key extends ParseKeys<Ns, TOpt, KPrefix> = string,
+  Key extends ParseKeys<Ns, TOpt, KPrefix>,
   Ns extends Namespace = _DefaultNamespace,
   KPrefix = undefined,
   TContext extends string | undefined = undefined,
@@ -96,7 +96,7 @@ export type IcuTransProps<
  */
 export interface IcuTransComponent {
   <
-    Key extends ParseKeys<Ns, TOpt, KPrefix> = string,
+    Key extends ParseKeys<Ns, TOpt, KPrefix>,
     Ns extends Namespace = _DefaultNamespace,
     KPrefix = undefined,
     TContext extends string | undefined = undefined,
@@ -123,7 +123,7 @@ export interface IcuTransComponent {
  */
 export interface IcuTransWithoutContextComponent {
   <
-    Key extends ParseKeys<Ns, TOpt, KPrefix> = string,
+    Key extends ParseKeys<Ns, TOpt, KPrefix>,
     Ns extends Namespace = _DefaultNamespace,
     KPrefix = undefined,
     TContext extends string | undefined = undefined,

--- a/package.json
+++ b/package.json
@@ -158,7 +158,8 @@
     "postversion": "npm run fix_dist_package && git push && git push --tags",
     "test": "vitest",
     "test:coverage": "npm run test -- --coverage --run",
-    "test:typescript": "vitest --workspace vitest.workspace.typescript.mts",
+    "test:typescript": "npm run test:typescript:issue-1899 && vitest --workspace vitest.workspace.typescript.mts",
+    "test:typescript:issue-1899": "bash test/typescript/issue-1899/check-types.sh",
     "contributors:add": "all-contributors add",
     "contributors:generate": "all-contributors generate",
     "prepare": "husky"

--- a/test/typescript/issue-1899/check-types.sh
+++ b/test/typescript/issue-1899/check-types.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Test script for issue #1899
+# https://github.com/i18next/react-i18next/issues/1899
+#
+# This script runs TypeScript with skipLibCheck: false and checks for errors
+# in index.d.ts. It ignores errors in node_modules (like @types/node issues).
+
+set -e
+
+cd "$(dirname "$0")/../../.."
+
+# Run tsc and capture output
+OUTPUT=$(npx tsc -p test/typescript/issue-1899/tsconfig.json --noEmit 2>&1 || true)
+
+# Check for errors in index.d.ts (our code)
+INDEX_ERRORS=$(echo "$OUTPUT" | grep "^index.d.ts" || true)
+
+if [ -n "$INDEX_ERRORS" ]; then
+  echo "ERROR: Type errors found in index.d.ts:"
+  echo "$INDEX_ERRORS"
+  exit 1
+fi
+
+echo "OK: No type errors in index.d.ts"
+exit 0

--- a/test/typescript/issue-1899/i18next.d.ts
+++ b/test/typescript/issue-1899/i18next.d.ts
@@ -1,0 +1,17 @@
+import 'i18next';
+
+/**
+ * Issue #1899: Type errors when custom resources are declared
+ * https://github.com/i18next/react-i18next/issues/1899
+ *
+ * This configuration reproduces the bug where declaring custom resources
+ * causes type errors in IcuTrans type definitions.
+ */
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    defaultNS: 'app';
+    resources: {
+      app: { foo: string; bar: string };
+    };
+  }
+}

--- a/test/typescript/issue-1899/import-check.ts
+++ b/test/typescript/issue-1899/import-check.ts
@@ -1,0 +1,11 @@
+/**
+ * Issue #1899: Type errors when custom resources are declared
+ * https://github.com/i18next/react-i18next/issues/1899
+ *
+ * This file imports from react-i18next to trigger TypeScript to check
+ * the type definitions in index.d.ts with custom resources declared.
+ */
+import type { IcuTrans } from 'react-i18next';
+
+// Just need to reference the type to trigger the check
+export type _Check = typeof IcuTrans;

--- a/test/typescript/issue-1899/tsconfig.json
+++ b/test/typescript/issue-1899/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "skipLibCheck": false
+  },
+  "include": ["./**/*"],
+  "exclude": []
+}

--- a/vitest.workspace.typescript.mts
+++ b/vitest.workspace.typescript.mts
@@ -9,6 +9,9 @@ export default defineWorkspace(
    */
   readdirSync('./test/typescript', { withFileTypes: true })
     .filter((dir) => dir.isDirectory())
+    // Exclude issue-1899 - it runs separately via test:typescript:issue-1899
+    // because it requires skipLibCheck: false which exposes @types/node errors
+    .filter((dir) => dir.name !== 'issue-1899')
     .reduce<UserProjectConfigExport[]>((workspaces, dir) => {
       const dirPath = `test/typescript/${dir.name}` as const;
 


### PR DESCRIPTION
This change fixes the issue raised by @robintown. The types for `Trans` did not have a default value for `Key`, which is what was causing the breakage.

Basically, IcuTrans requires a key, so there is always a value to infer from. For Trans, where the key is optional, the value was inferred as the full `ParseKeys<...>` type. The bug was introducing a default of `= string`. This is unnecessary and was the root cause of the problem.

@robintown can you please try this fix on your local codebase and confirm it works?

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
