### PR TITLE
Security: Global singleton i18n instance can leak state across SSR requests

### DIFF
--- a/src/i18nInstance.js
+++ b/src/i18nInstance.js
@@ -1,7 +1,8 @@
 let i18nInstance;
+const isBrowser = typeof window !== 'undefined';
 
 export const setI18n = (instance) => {
-  i18nInstance = instance;
+  if (isBrowser) i18nInstance = instance;
 };
 
-export const getI18n = () => i18nInstance;
+export const getI18n = () => (isBrowser ? i18nInstance : undefined);


### PR DESCRIPTION
## Problem

The library stores the active i18n instance in a module-level variable (`i18nInstance`). In server-side rendering environments, module globals are shared across concurrent requests. If different requests/users initialize different instances or language/resource state, this can cause cross-request state bleed (wrong language, namespace data, or tenant-specific resources being reused). `getInitialProps` in `src/context.js` reads from this shared singleton, which amplifies this risk.

**Severity**: `medium`
**File**: `src/i18nInstance.js`

## Solution

Avoid process-global mutable i18n state for SSR. Pass i18n through request-scoped context/providers only, or keep a per-request instance map keyed by request context. Document that singleton APIs are client-only and provide SSR-safe alternatives.

## Changes

- `src/i18nInstance.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
