### PR TITLE
Security: Global mutable default options are shared across consumers/requests

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -15,7 +15,16 @@ let defaultOptions = {
 };
 
 export const setDefaults = (options = {}) => {
-  defaultOptions = { ...defaultOptions, ...options };
+  defaultOptions = {
+    ...defaultOptions,
+    ...options,
+    ...(options.transKeepBasicHtmlNodesFor
+      ? { transKeepBasicHtmlNodesFor: [...options.transKeepBasicHtmlNodesFor] }
+      : {}),
+  };
 };
 
-export const getDefaults = () => defaultOptions;
+export const getDefaults = () => ({
+  ...defaultOptions,
+  transKeepBasicHtmlNodesFor: [...defaultOptions.transKeepBasicHtmlNodesFor],
+});


### PR DESCRIPTION
## Problem

`defaultOptions` is a mutable module-global object updated via `setDefaults`. In SSR or multi-instance usage, one initialization path can overwrite defaults for others, creating cross-request/config contamination. While mostly integrity-related, it can affect security-sensitive rendering behavior (e.g., escaping/unescaping behavior) if options differ by context.

**Severity**: `low`
**File**: `src/defaults.js`

## Solution

Use immutable/request-scoped configuration instead of mutating module globals. For SSR, derive options from the active i18n instance/context at render time. If globals must remain, clearly document non-thread-safe behavior.

## Changes

- `src/defaults.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
