### PR TITLE
fix(types): accept selector i18nKey on <Trans> under enableSelector: 'strict'

### DIFF
--- a/TransWithoutContext.d.ts
+++ b/TransWithoutContext.d.ts
@@ -106,7 +106,9 @@ export interface TransSelector {
   ): React.ReactElement;
 }
 
-export const Trans: _EnableSelector extends true | 'optimize' ? TransSelector : TransLegacy;
+export const Trans: _EnableSelector extends true | 'optimize' | 'strict'
+  ? TransSelector
+  : TransLegacy;
 
 export function nodesToString(
   children: React.ReactNode,

--- a/test/typescript/selector-strict/Trans.test.tsx
+++ b/test/typescript/selector-strict/Trans.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import * as React from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+
+describe('<Trans /> under enableSelector: "strict"', () => {
+  describe('default namespace', () => {
+    it('requires an explicit namespace prefix', () => {
+      <Trans i18nKey={($) => (expectTypeOf($.custom.foo).toEqualTypeOf<'foo'>(), $.custom.foo)} />;
+    });
+
+    it(`raises a TypeError given a flat-primary path (no ns prefix)`, () => {
+      // @ts-expect-error
+      <Trans i18nKey={($) => $.foo} />;
+    });
+
+    it(`raises a TypeError given a key that doesn't exist`, () => {
+      // @ts-expect-error
+      <Trans i18nKey={($) => $.custom.Nope} />;
+    });
+  });
+
+  describe('named namespace', () => {
+    it('standard usage', () => {
+      <Trans
+        ns="custom"
+        i18nKey={($) => (expectTypeOf($.custom.foo).toEqualTypeOf<'foo'>(), $.custom.foo)}
+      />;
+    });
+
+    it(`raises a TypeError given a namespace that doesn't exist`, () => {
+      expectTypeOf<React.ComponentProps<typeof Trans>>()
+        .toHaveProperty('ns')
+        .extract<'Nope'>()
+        // @ts-expect-error
+        .toMatchTypeOf<'Nope'>();
+    });
+  });
+
+  describe('array namespace', () => {
+    it('always routes via an explicit namespace prefix', () => (
+      <>
+        <Trans
+          ns={['alternate', 'custom']}
+          i18nKey={($) => (expectTypeOf($.alternate.baz).toEqualTypeOf<'baz'>(), $.alternate.baz)}
+        />
+        <Trans
+          ns={['alternate', 'custom']}
+          i18nKey={($) => (expectTypeOf($.custom.bar).toEqualTypeOf<'bar'>(), $.custom.bar)}
+        />
+        <Trans
+          ns={['custom', 'alternate']}
+          i18nKey={($) => (
+            expectTypeOf($.alternate.foobar.deep.deeper.deeeeeper).toEqualTypeOf<'foobar'>(),
+            $.alternate.foobar.deep.deeper.deeeeeper
+          )}
+        />
+      </>
+    ));
+
+    it(`raises a TypeError given a flat-primary path`, () => {
+      // @ts-expect-error
+      <Trans ns={['alternate', 'custom']} i18nKey={($) => $.baz} />;
+      // @ts-expect-error
+      <Trans ns={['custom', 'alternate']} i18nKey={($) => $.bar} />;
+    });
+
+    it(`raises a TypeError given a key that's not present inside any namespace`, () => {
+      // @ts-expect-error
+      <Trans ns={['alternate', 'custom']} i18nKey={($) => $.custom.baz} />;
+    });
+  });
+
+  describe('usage with `t` function', () => {
+    it('should work when providing `t` function', () => {
+      const { t } = useTranslation('alternate');
+      <Trans
+        t={t}
+        i18nKey={($) => (
+          expectTypeOf($.alternate.foobar.barfoo).toEqualTypeOf<'barfoo'>(),
+          $.alternate.foobar.barfoo
+        )}
+      />;
+    });
+  });
+
+  describe('interpolation', () => {
+    it('should work with text and interpolation', () => {
+      expectTypeOf(Trans).toBeCallableWith({
+        children: ['foo ', { var: '' }],
+      });
+    });
+
+    it('should work with Interpolation in HTMLElement', () => {
+      expectTypeOf(Trans).toBeCallableWith({
+        children: (
+          <>
+            foo <strong>{{ var: '' }}</strong>
+          </>
+        ),
+      });
+    });
+
+    it('should work with text and interpolation as children of an HTMLElement', () => {
+      expectTypeOf(Trans).toBeCallableWith({
+        children: <span>foo {{ var: '' }}</span>,
+      });
+    });
+  });
+});

--- a/test/typescript/selector-strict/i18next.d.ts
+++ b/test/typescript/selector-strict/i18next.d.ts
@@ -1,0 +1,27 @@
+import 'i18next';
+
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    defaultNS: 'custom';
+    allowObjectInHTMLChildren: true;
+    enableSelector: 'strict';
+    resources: {
+      custom: {
+        foo: 'foo';
+        bar: 'bar';
+      };
+
+      alternate: {
+        baz: 'baz';
+        foobar: {
+          barfoo: 'barfoo';
+          deep: {
+            deeper: {
+              deeeeeper: 'foobar';
+            };
+          };
+        };
+      };
+    };
+  }
+}

--- a/test/typescript/selector-strict/tsconfig.json
+++ b/test/typescript/selector-strict/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["./**/*"],
+  "exclude": []
+}


### PR DESCRIPTION
## Problem

Under `CustomTypeOptions.enableSelector: 'strict'`, every `<Trans i18nKey={($) => ...}>` call site fails to typecheck:

```
Type '($: any) => any' is not assignable to type '"some-key-from-resources" | ... | undefined'.
Parameter '$' implicitly has an 'any' type.
```

The cause is in `TransWithoutContext.d.ts`:

```ts
export const Trans: _EnableSelector extends true | 'optimize' ? TransSelector : TransLegacy;
```

`'strict'` doesn't match `true | 'optimize'`, so `Trans` collapses to `TransLegacy`, whose `i18nKey: Key` is a string union. The runtime, however, accepts selector `i18nKey` regardless of mode — `TransWithoutContext.js` calls `keyFromSelector(i18nKey)` whenever `typeof i18nKey === 'function'`. So this is a type-side oversight; the runtime is already correct.

## Repro

1. Set `CustomTypeOptions.enableSelector: 'strict'`.
2. `<Trans i18nKey={($) => $.someNs["Some key"]}>` — errors at compile time, renders fine at runtime.

## Fix

Widen the conditional to include `'strict'`:

```diff
-export const Trans: _EnableSelector extends true | 'optimize' ? TransSelector : TransLegacy;
+export const Trans: _EnableSelector extends true | 'optimize' | 'strict' ? TransSelector : TransLegacy;
```

## Tests

Adds `test/typescript/selector-strict/` mirroring `selector-optimize/` (same `i18next.d.ts` / `tsconfig.json` shape, with `enableSelector: 'strict'`). The `Trans.test.tsx` covers the strict-mode selector contract:

- Default namespace requires an explicit prefix (`$.custom.foo`).
- Flat-primary paths (`$.foo`) raise a TypeError.
- Named-namespace + array-namespace paths still typecheck via the namespace prefix.
- `t` from `useTranslation` flows through.
- Interpolation cases mirror the optimize-mode tests.

`keyPrefix` cases are intentionally not covered — strict mode interacts with `keyPrefix` differently and is out of scope here. All 383 type-tests in the existing suite still pass.

```
$ npx vitest --config vitest.workspace.typescript.mts run
 Test Files  42 passed (42)
      Tests  383 passed (383)
Type Errors  no errors
```