### PR TITLE
docs: point Trans component links at the current docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Some basics of i18next and some cool possibilities on how to optimize your local
 
 #### v9
 
-- react >= **0.14.0** (in case of < v16 or preact you will need to define parent in [Trans component](https://react.i18next.com/legacy-v9/trans-component#trans-props) or globally in [i18next.react options](https://react.i18next.com/legacy-v9/trans-component#additional-options-on-i-18-next-init))
+- react >= **0.14.0** (in case of < v16 or preact you will need to define parent in [Trans component](https://react.i18next.com/latest/trans-component#trans-props) or globally in [i18next.react options](https://react.i18next.com/latest/trans-component#i18next-options))
 - i18next >= **2.0.0**
 
 ## Core Contributors


### PR DESCRIPTION
Both documentation links in the requirements section return **404** — the whole `legacy-v9` section is gone from react.i18next.com (`https://react.i18next.com/legacy-v9/` itself 404s too).

| Old (404) | New (200) |
| --- | --- |
| `react.i18next.com/legacy-v9/trans-component#trans-props` | `react.i18next.com/latest/trans-component#trans-props` |
| `react.i18next.com/legacy-v9/trans-component#additional-options-on-i-18-next-init` | `react.i18next.com/latest/trans-component#i18next-options` |

The first anchor still exists verbatim on the current page. The second one was renamed — the equivalent section is now `#i18next-options` — so the link points there instead of at a missing anchor.

Documentation only.