### PR TITLE
fix(types): allow selector keyPrefix in useTranslation under enableSelector 'strict'

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -222,7 +222,7 @@ export type FallbackNs<Ns> = Ns extends undefined
     ? Ns
     : _DefaultNamespace;
 
-export const useTranslation: _EnableSelector extends true | 'optimize'
+export const useTranslation: _EnableSelector extends true | 'optimize' | 'strict'
   ? UseTranslationSelector
   : UseTranslationLegacy;
 

--- a/test/typescript/selector-strict/useTranslation.test.ts
+++ b/test/typescript/selector-strict/useTranslation.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expectTypeOf, assertType } from 'vitest';
+import { useTranslation } from 'react-i18next';
+
+describe('useTranslation under enableSelector: "strict"', () => {
+  describe('default namespace', () => {
+    it('requires an explicit namespace prefix', () => {
+      const [t] = useTranslation();
+
+      expectTypeOf(t(($) => $.custom.foo)).toEqualTypeOf<'foo'>();
+    });
+
+    it('raises a TypeError given a flat-primary path (no ns prefix)', () => {
+      const [t] = useTranslation();
+      // @ts-expect-error
+      assertType<string>(t(($) => $.foo));
+    });
+  });
+
+  describe('named namespace', () => {
+    it('still requires the namespace prefix', () => {
+      const [t] = useTranslation('alternate');
+
+      expectTypeOf(t(($) => $.alternate.baz)).toEqualTypeOf<'baz'>();
+    });
+
+    it('raises a TypeError given a key that is not in the namespace', () => {
+      const [t] = useTranslation('alternate');
+      // @ts-expect-error
+      assertType<string>(t(($) => $.alternate.fake));
+    });
+  });
+
+  describe('namespace as array', () => {
+    it('exposes every namespace under its own prefix', () => {
+      const [t] = useTranslation(['alternate', 'custom']);
+
+      expectTypeOf(t(($) => $.alternate.baz)).toEqualTypeOf<'baz'>();
+      expectTypeOf(t(($) => $.custom.foo)).toEqualTypeOf<'foo'>();
+    });
+
+    it('raises a TypeError given a flat-primary path', () => {
+      const [t] = useTranslation(['alternate', 'custom']);
+      // @ts-expect-error
+      assertType<string>(t(($) => $.baz));
+    });
+  });
+
+  describe('with `keyPrefix`', () => {
+    it('should work with a selector keyPrefix', () => {
+      const [t] = useTranslation('alternate', {
+        keyPrefix: ($) => $.alternate.foobar.deep,
+      });
+
+      expectTypeOf(t(($) => $.deeper.deeeeeper)).toEqualTypeOf<'foobar'>();
+    });
+
+    it('should return objects from a selector keyPrefix', () => {
+      const [t] = useTranslation('alternate', {
+        keyPrefix: ($) => $.alternate.foobar,
+      });
+
+      expectTypeOf(t(($) => $.deep.deeper, { returnObjects: true })).toEqualTypeOf<{
+        deeeeeper: 'foobar';
+      }>();
+    });
+
+    it('raises a TypeError given a key outside the selector keyPrefix', () => {
+      const [t] = useTranslation('alternate', {
+        keyPrefix: ($) => $.alternate.foobar.deep,
+      });
+      // @ts-expect-error
+      assertType<string>(t(($) => $.abc));
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`useTranslation` is gated on `_EnableSelector extends true | 'optimize'`, which
excludes `'strict'`. Under `enableSelector: 'strict'` it resolves to `UseTranslationLegacy`, so the selector-form `keyPrefix` overload is gone entirely:

```ts
// test/typescript/selector-strict — enableSelector: 'strict'
const { t } = useTranslation('alternate', {
  keyPrefix: ($) => $.alternate.foobar.deep,
});
//           ^ Type '($: any) => any' is not assignable to type 'undefined'.
```

`Trans` in `TransWithoutContext.d.ts` already gates on `true | 'optimize' | 'strict'`,
so `useTranslation` is the one export `'strict'` was never added to.

Companion to i18next/i18next#2446, which fixed the same omission in `getFixedT`.

## Fix

```diff
-export const useTranslation: _EnableSelector extends true | 'optimize'
+export const useTranslation: _EnableSelector extends true | 'optimize' | 'strict'
   ? UseTranslationSelector
   : UseTranslationLegacy;
```

Adds `useTranslation.test.ts` to the existing `selector-strict` scenario. It was the
only scenario without one, which is why this went unnoticed:

```ts
it('should work with a selector keyPrefix', () => {
  const [t] = useTranslation('alternate', {
    keyPrefix: ($) => $.alternate.foobar.deep,
  });

  expectTypeOf(t(($) => $.deeper.deeeeeper)).toEqualTypeOf<'foobar'>();
});
```

Reverting the one-line change fails 3 of its cases.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
